### PR TITLE
remove parseInvite and correct tests to suit

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,29 @@ Scuttle Invite provides an easy-to-use set of functions that allow you to invite
 
 ```js
 const invites = ScuttleInvite(server)
-const params = { body: `My fellow Hermies, come cluster at the official opening of Crabland, we'll be cracking open a few bottles of bubbly`, root: rootId }
-invites.async.private.publish(params, callback)
+const params = {
+  body: `My fellow Hermies, come cluster at the official opening of Crabland, we'll be cracking open a few bottles of bubbly`,
+  root: rootId
+}
+invites.async.private.publish(params, (err, invite) => {
+  // returns the sent decrypted invite message
+})
 ```
+
+To reply to an invite:
+
+```js
+const invites = ScuttleInvite(server)
+const replyParams = {
+  body: 'glass of milk?',
+  root: rootId
+}
+invites.async.private.reply(inviteId, replyParams, (err, reply) => {
+  // returns the sent decrypted reply message
+})
+```
+
+See the [tests](./test) for more examples...
 
 ## API
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const methods = require('./methods')
-const PLUGIN_DEPS = ['invites', 'private', 'backlinks']
+const PLUGIN_DEPS = ['private', 'query']
 const Inject = require('scuttle-inject')
 
 module.exports = function (server, opts) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const methods = require('./methods')
-const PLUGIN_DEPS = ['private', 'query']
+const PLUGIN_DEPS = ['backlinks', 'private', 'query']
 const Inject = require('scuttle-inject')
 
 module.exports = function (server, opts) {

--- a/invites/async/canReply.js
+++ b/invites/async/canReply.js
@@ -1,11 +1,10 @@
 module.exports = function (server) {
   return function canReply (invite, callback) {
     const { value: { author, content: { recps } } } = invite
-    server.whoami((err, whoami) => {
-      let recipients = recps.filter(recp => recp !== whoami.id)
-      if (recipients.length !== 1) return callback(false)
-      let recipient = recipients[0]
-      callback(recipient === author)
-    })
+
+    let otherRecp = recps.find(recp => recp !== server.id)
+    if (!otherRecp) return callback(null, false)
+
+    callback(null, otherRecp === author)
   }
 }

--- a/invites/async/canReply.js
+++ b/invites/async/canReply.js
@@ -1,10 +1,11 @@
 module.exports = function (server) {
   return function canReply (invite, callback) {
-    const { author, recipient } = invite
+    const { value: { author, content: { recps } } } = invite
     server.whoami((err, whoami) => {
-      var bool = (recipient === whoami.id) &&
-        (recipient !== author)
-      callback(bool)
+      let recipients = recps.filter(recp => recp !== whoami.id)
+      if (recipients.length !== 1) return callback(false)
+      let recipient = recipients[0]
+      callback(recipient === author)
     })
   }
 }

--- a/invites/async/getInvite.js
+++ b/invites/async/getInvite.js
@@ -1,5 +1,4 @@
 const { parseInvite } = require('ssb-invite-schema')
-const getContent = require('ssb-msg-content')
 
 module.exports = function (server) {
   return function getInvite (key, callback) {

--- a/invites/async/getInvite.js
+++ b/invites/async/getInvite.js
@@ -3,9 +3,10 @@ const getContent = require('ssb-msg-content')
 
 module.exports = function (server) {
   return function getInvite (key, callback) {
-    server.invites.getInvite(key, (err, invite) => {
+    server.get(key, (err, value) => {
       if (err) return callback(err)
-      return callback(null, parseInvite(invite))
+      const invite = { key, value }
+      return callback(null, invite)
     })
   }
 }

--- a/invites/async/getReply.js
+++ b/invites/async/getReply.js
@@ -2,9 +2,10 @@ const { parseReply } = require('scuttle-invite-schema')
 
 module.exports = function (server) {
   return function getReply (key, callback) {
-    server.invites.getReply(key, (err, reply) => {
+    server.get(key, (err, value) => {
       if (err) return callback(err)
-      return callback(null, parseReply(reply))
+      const reply = { key, value }
+      return callback(null, reply)
     })
   }
 }

--- a/invites/async/private/publish.js
+++ b/invites/async/private/publish.js
@@ -24,7 +24,7 @@ module.exports = function (server) {
     server.private.publish(invite, invite.recps, (err, inv) => {
       if (err) return callback(err)
       var decrypted = server.private.unbox(inv)
-      callback(null, parseInvite(decrypted))
+      callback(null, decrypted)
     })
   }
 }

--- a/invites/async/private/publish.js
+++ b/invites/async/private/publish.js
@@ -6,21 +6,21 @@ const {
   }
 } = require('ssb-invite-schema')
 
+const buildError = require('../../lib/buildError')
+
 module.exports = function (server) {
   return function publish (params, callback) {
-    const invite = Object.assign({}, {
+    // params must contain: root, recps
+
+    const invite = Object.assign({}, params, {
       type: 'invite',
-    }, params, {
       version: V1_SCHEMA_VERSION_STRING
     })
 
-    if (!invite.recps) invite.recps = []
-    if (!invite.recps.includes(server.id)) invite.recps = [...invite.recps, server.id]
+    if (!isInvite(invite)) return callback(buildError(invite))
 
-    if (!isInvite(invite)) {
-      var errors = invite.errors.map(e => e.field).join(', ')
-      return callback(new Error(`invalid: ${errors}`))
-    }
+    if (!invite.recps.includes(server.id)) invite.recps.push(server.id)
+
     server.private.publish(invite, invite.recps, (err, inv) => {
       if (err) return callback(err)
       var decrypted = server.private.unbox(inv)

--- a/invites/async/private/reply.js
+++ b/invites/async/private/reply.js
@@ -10,6 +10,8 @@ const {
   }
 } = require('ssb-invite-schema')
 
+const buildError = require('../../lib/buildError')
+
 module.exports = function (server) {
   const getInvite = require('../getInvite')(server)
 
@@ -41,14 +43,11 @@ module.exports = function (server) {
             }
           )
 
-          if (!reply.recps) reply.recps = []
-          if (!reply.recps.includes(server.id)) reply.recps = [...reply.recps, server.id]
-
           if (!isReply(reply)) return callback(buildError(reply))
 
-          server.private.publish(reply, reply.recps, (err, resp) => {
+          server.private.publish(reply, reply.recps, (err, repl) => {
             if (err) return callback(err)
-            var decrypted = server.private.unbox(resp)
+            var decrypted = server.private.unbox(repl)
             callback(null, decrypted)
           })
         })

--- a/invites/async/private/reply.js
+++ b/invites/async/private/reply.js
@@ -34,7 +34,7 @@ module.exports = function (server) {
       server.private.publish(reply, reply.recps, (err, resp) => {
         if (err) return callback(err)
         var decrypted = server.private.unbox(resp)
-        callback(null, parseReply(decrypted))
+        callback(null, decrypted)
       })
     })
   }

--- a/invites/async/private/reply.js
+++ b/invites/async/private/reply.js
@@ -26,9 +26,8 @@ module.exports = function (server) {
     getInvite(reply.branch, (err, invite) => {
       var decryptedInvite = server.private.unbox(invite) || invite
       if (err) return callback(err)
-      var whoami = server.whoami()
       var notInvited = decryptedInvite &&
-        (decryptedInvite.recipient !== whoami.id)
+        (decryptedInvite.recipient !== server.id)
       if (notInvited) return callback(new Error(`invalid: you are not invited`))
 
       server.private.publish(reply, reply.recps, (err, resp) => {

--- a/invites/async/private/reply.js
+++ b/invites/async/private/reply.js
@@ -41,6 +41,9 @@ module.exports = function (server) {
             }
           )
 
+          if (!reply.recps) reply.recps = []
+          if (!reply.recps.includes(server.id)) reply.recps = [...reply.recps, server.id]
+
           if (!isReply(reply)) return callback(buildError(reply))
 
           server.private.publish(reply, reply.recps, (err, resp) => {

--- a/invites/async/private/reply.js
+++ b/invites/async/private/reply.js
@@ -1,3 +1,7 @@
+const getContent = require('ssb-msg-content')
+const pull = require('pull-stream')
+const { heads } = require('ssb-sort')
+
 const {
   isReply,
   parseReply,
@@ -9,32 +13,43 @@ const {
 module.exports = function (server) {
   const getInvite = require('../getInvite')(server)
 
-  return function reply (params, callback) {
-    const reply = Object.assign({}, {
-      type: 'invite-reply',
-    }, params, {
-      version: V1_SCHEMA_VERSION_STRING
-    })
-
-    if (!reply.recps) reply.recps = []
-    if (!reply.recps.includes(server.id)) reply.recps = [...reply.recps, server.id]
-
-    if (!isReply(reply)) {
-      var errors = reply.errors.map(e => e.field).join(', ')
-      return callback(new Error(`invalid: ${errors}`))
-    }
-    getInvite(reply.branch, (err, invite) => {
-      var decryptedInvite = server.private.unbox(invite) || invite
+  return function reply (inviteKey, params, callback) {
+    getInvite(inviteKey, (err, invite) => {
       if (err) return callback(err)
-      var notInvited = decryptedInvite &&
-        (decryptedInvite.recipient !== server.id)
-      if (notInvited) return callback(new Error(`invalid: you are not invited`))
+      var decryptedInvite = server.private.unbox(invite) || invite
 
-      server.private.publish(reply, reply.recps, (err, resp) => {
-        if (err) return callback(err)
-        var decrypted = server.private.unbox(resp)
-        callback(null, decrypted)
-      })
+      if (!isInvite(decryptedInvite)) return callback(new Error(`${inviteKey} is not a valid invite, cannot reply to this`))
+
+      const { recps = [], root } = getContent(invite)
+
+      const iWasInvited = Boolean(recps.find(recp => recp === server.id))
+      if (!iWasInvited) return callback(new Error(`invalid: you are not invited`))
+
+      pull(
+        backlinksSource(root),
+        pull.collect((err, msgs) => {
+          if (err) return callback(err)
+
+          const reply = Object.assign({},
+            params,
+            {
+              type: 'invite-reply',
+              version: V1_SCHEMA_VERSION_STRING,
+              recps,
+              root,
+              branch: heads(msgs)
+            }
+          )
+
+          if (!isReply(reply)) return callback(buildError(reply))
+
+          server.private.publish(reply, reply.recps, (err, resp) => {
+            if (err) return callback(err)
+            var decrypted = server.private.unbox(resp)
+            callback(null, decrypted)
+          })
+        })
+      )
     })
   }
 }

--- a/invites/async/publish.js
+++ b/invites/async/publish.js
@@ -8,19 +8,19 @@ const {
 
 module.exports = function (server) {
   return function publish (params, callback) {
-    const invite = Object.assign({}, {
+    // params must contain: root, recps
+
+    const invite = Object.assign({}, params, {
       type: 'invite',
-    }, params, {
       version: V1_SCHEMA_VERSION_STRING
     })
-
-    if (!invite.recps) invite.recps = []
-    if (!invite.recps.includes(server.id)) invite.recps = [...invite.recps, server.id]
 
     if (!isInvite(invite)) {
       var errors = invite.errors.map(e => e.field).join(', ')
       return callback(new Error(`invalid: ${errors}`))
     }
+
+    if (!invite.recps.includes(server.id)) invite.recps.push(server.id)
 
     server.publish(invite, callback)
   }

--- a/invites/async/publish.js
+++ b/invites/async/publish.js
@@ -22,9 +22,6 @@ module.exports = function (server) {
       return callback(new Error(`invalid: ${errors}`))
     }
 
-    server.publish(invite, (err, data) => {
-      if (err) return callback(err)
-      callback(null, data)
-    })
+    server.publish(invite, callback)
   }
 }

--- a/invites/async/publish.js
+++ b/invites/async/publish.js
@@ -24,7 +24,7 @@ module.exports = function (server) {
 
     server.publish(invite, (err, data) => {
       if (err) return callback(err)
-      callback(null, parseInvite(data))
+      callback(null, data)
     })
   }
 }

--- a/invites/async/publish.js
+++ b/invites/async/publish.js
@@ -6,6 +6,8 @@ const {
   }
 } = require('ssb-invite-schema')
 
+const buildError = require('../../lib/buildError')
+
 module.exports = function (server) {
   return function publish (params, callback) {
     // params must contain: root, recps
@@ -15,10 +17,7 @@ module.exports = function (server) {
       version: V1_SCHEMA_VERSION_STRING
     })
 
-    if (!isInvite(invite)) {
-      var errors = invite.errors.map(e => e.field).join(', ')
-      return callback(new Error(`invalid: ${errors}`))
-    }
+    if (!isInvite(invite)) return callback(buildError(invite))
 
     if (!invite.recps.includes(server.id)) invite.recps.push(server.id)
 

--- a/invites/async/reply.js
+++ b/invites/async/reply.js
@@ -10,6 +10,7 @@ const {
     V1_SCHEMA_VERSION_STRING
   }
 } = require('ssb-invite-schema')
+
 const buildError = require('../../lib/buildError')
 
 module.exports = function (server) {
@@ -51,7 +52,6 @@ module.exports = function (server) {
       )
     })
   }
-
 
   function backlinksSource (root) {
     return server.backlinks.read({

--- a/invites/async/reply.js
+++ b/invites/async/reply.js
@@ -1,37 +1,39 @@
+const getContent = require('ssb-msg-content')
 const {
+  isInvite,
   isReply,
   parseReply,
   versionStrings: {
     V1_SCHEMA_VERSION_STRING
   }
 } = require('ssb-invite-schema')
-
+const buildError = require('../../lib/buildError')
 
 module.exports = function (server) {
   const getInvite = require('./getInvite')(server)
 
-  return function reply (params, callback) {
-    const reply = Object.assign({}, {
-      type: 'invite-reply',
-    }, params, {
-      version: V1_SCHEMA_VERSION_STRING
-    })
-
-    if (!reply.recps) reply.recps = []
-    if (!reply.recps.includes(server.id)) reply.recps = [...reply.recps, server.id]
-
-    if (!isReply(reply)) {
-      var errors = reply.errors.map(e => e.field).join(', ')
-      return callback(new Error(`invalid: ${errors}`))
-    }
-
-    getInvite(reply.branch, (err, invite) => {
+  return function reply (inviteKey, params, callback) {
+    getInvite(inviteKey, (err, invite) => {
       if (err) return callback(err)
-      const { value: { content: { recps } } } = invite
-      var whoami = server.whoami()
-      let recipients = recps.filter(recp => recp !== whoami.id)
-      var notInvited = recipients.length !== 1
-      if (notInvited) return callback(new Error(`invalid: you are not invited`))
+      if (!isInvite(invite)) return callback(new Error(`${inviteKey} is not a valid invite, cannot reply to this`))
+
+      const { recps = [], root } = getContent(invite)
+
+      const iWasInvited = Boolean(recps.find(recp => recp === server.id))
+      if (!iWasInvited) return callback(new Error(`invalid: you are not invited`))
+
+      const reply = Object.assign({},
+        params,
+        { 
+          type: 'invite-reply',
+          version: V1_SCHEMA_VERSION_STRING,
+          recps,
+          root,
+          branch: inviteKey
+        }
+      )
+
+      if (!isReply(reply)) return callback(buildError(reply))
 
       server.publish(reply, callback)
     })

--- a/invites/async/reply.js
+++ b/invites/async/reply.js
@@ -24,43 +24,28 @@ module.exports = function (server) {
 
       const iWasInvited = Boolean(recps.find(recp => recp === server.id))
       if (!iWasInvited) return callback(new Error(`invalid: you are not invited`))
-        
-      const reply = Object.assign({},
-        params,
-        { 
-          type: 'invite-reply',
-          version: V1_SCHEMA_VERSION_STRING,
-          recps,
-          root,
-          branch: inviteKey
-        }
+
+      pull(
+        backlinksSource(root),
+        pull.collect((err, msgs) => {
+          if (err) return callback(err)
+
+          const reply = Object.assign({},
+            params,
+            {
+              type: 'invite-reply',
+              version: V1_SCHEMA_VERSION_STRING,
+              recps,
+              root,
+              branch: heads(msgs)
+            }
+          )
+
+          if (!isReply(reply)) return callback(buildError(reply))
+
+          server.publish(reply, callback)
+        })
       )
-      if (!isReply(reply)) return callback(buildError(reply))
-
-      server.publish(reply, callback)
-
-      // pull(
-      //   backlinksSource(root),
-      //   pull.collect((err, msgs) => {
-      //     if (err) return callback(err)
-
-      //     const reply = Object.assign({},
-      //       params,
-      //       { 
-      //         type: 'invite-reply',
-      //         version: V1_SCHEMA_VERSION_STRING,
-      //         recps,
-      //         root,
-      //         branch: heads(msgs)
-      //       }
-      //     )
-
-      //     console.log(reply)
-      //     if (!isReply(reply)) return callback(buildError(reply))
-
-      //     server.publish(reply, callback)
-      //   })
-      // )
     })
   }
 

--- a/invites/async/reply.js
+++ b/invites/async/reply.js
@@ -41,6 +41,9 @@ module.exports = function (server) {
             }
           )
 
+          if (!reply.recps) reply.recps = []
+          if (!reply.recps.includes(server.id)) reply.recps = [...reply.recps, server.id]
+
           if (!isReply(reply)) return callback(buildError(reply))
 
           server.publish(reply, callback)

--- a/invites/async/reply.js
+++ b/invites/async/reply.js
@@ -33,10 +33,7 @@ module.exports = function (server) {
       var notInvited = recipients.length !== 1
       if (notInvited) return callback(new Error(`invalid: you are not invited`))
 
-      server.publish(reply, (err, data) => {
-        if (err) return callback(err)
-        callback(null, data)
-      })
+      server.publish(reply, callback)
     })
   }
 }

--- a/invites/async/reply.js
+++ b/invites/async/reply.js
@@ -1,4 +1,7 @@
 const getContent = require('ssb-msg-content')
+const pull = require('pull-stream')
+const { heads } = require('ssb-sort')
+
 const {
   isInvite,
   isReply,
@@ -21,7 +24,7 @@ module.exports = function (server) {
 
       const iWasInvited = Boolean(recps.find(recp => recp === server.id))
       if (!iWasInvited) return callback(new Error(`invalid: you are not invited`))
-
+        
       const reply = Object.assign({},
         params,
         { 
@@ -32,10 +35,41 @@ module.exports = function (server) {
           branch: inviteKey
         }
       )
-
       if (!isReply(reply)) return callback(buildError(reply))
 
       server.publish(reply, callback)
+
+      // pull(
+      //   backlinksSource(root),
+      //   pull.collect((err, msgs) => {
+      //     if (err) return callback(err)
+
+      //     const reply = Object.assign({},
+      //       params,
+      //       { 
+      //         type: 'invite-reply',
+      //         version: V1_SCHEMA_VERSION_STRING,
+      //         recps,
+      //         root,
+      //         branch: heads(msgs)
+      //       }
+      //     )
+
+      //     console.log(reply)
+      //     if (!isReply(reply)) return callback(buildError(reply))
+
+      //     server.publish(reply, callback)
+      //   })
+      // )
+    })
+  }
+
+
+  function backlinksSource (root) {
+    return server.backlinks.read({
+      query: [{
+        $filter: {dest: root}
+      }]
     })
   }
 }

--- a/invites/async/reply.js
+++ b/invites/async/reply.js
@@ -42,9 +42,6 @@ module.exports = function (server) {
             }
           )
 
-          if (!reply.recps) reply.recps = []
-          if (!reply.recps.includes(server.id)) reply.recps = [...reply.recps, server.id]
-
           if (!isReply(reply)) return callback(buildError(reply))
 
           server.publish(reply, callback)

--- a/invites/async/reply.js
+++ b/invites/async/reply.js
@@ -27,13 +27,15 @@ module.exports = function (server) {
 
     getInvite(reply.branch, (err, invite) => {
       if (err) return callback(err)
+      const { value: { content: { recps } } } = invite
       var whoami = server.whoami()
-      var notInvited = invite.recipient !== whoami.id
+      let recipients = recps.filter(recp => recp !== whoami.id)
+      var notInvited = recipients.length !== 1
       if (notInvited) return callback(new Error(`invalid: you are not invited`))
 
       server.publish(reply, (err, data) => {
         if (err) return callback(err)
-        callback(null, parseReply(data))
+        callback(null, data)
       })
     })
   }

--- a/lib/buildError.js
+++ b/lib/buildError.js
@@ -1,0 +1,4 @@
+module.exports = function buildError (obj) {
+  var errors = obj.errors.map(e => e.field).join(', ')
+  return new Error(`invalid: ${errors}`)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,7 +131,8 @@
     "async-single": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/async-single/-/async-single-1.0.5.tgz",
-      "integrity": "sha1-El3QneldPqMKN4rb7QIQkhebA8k="
+      "integrity": "sha1-El3QneldPqMKN4rb7QIQkhebA8k=",
+      "dev": true
     },
     "async-write": {
       "version": "2.1.0",
@@ -142,7 +143,8 @@
     "atomic-file": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-1.1.5.tgz",
-      "integrity": "sha512-TG+5YFiaKQ6CZiSQsosGMJ/IJzwMZ4V/rSdEXlD6+DwKyv8OyeUcprq34kp4yuS6bfQYXhxBC2Vm8PWo+iKBGQ=="
+      "integrity": "sha512-TG+5YFiaKQ6CZiSQsosGMJ/IJzwMZ4V/rSdEXlD6+DwKyv8OyeUcprq34kp4yuS6bfQYXhxBC2Vm8PWo+iKBGQ==",
+      "dev": true
     },
     "attach-ware": {
       "version": "1.1.1",
@@ -811,7 +813,8 @@
     "deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -1147,6 +1150,7 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.0.tgz",
       "integrity": "sha1-Ns4Gq+Lg4BxE3WnyoWUwWiMgZJs=",
+      "dev": true,
       "requires": {
         "level-codec": "6.2.0"
       },
@@ -1154,7 +1158,8 @@
         "level-codec": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-6.2.0.tgz",
-          "integrity": "sha1-pLUkS7akwvcj1oodZOmAxTYn2dQ="
+          "integrity": "sha1-pLUkS7akwvcj1oodZOmAxTYn2dQ=",
+          "dev": true
         }
       }
     },
@@ -1268,6 +1273,7 @@
       "version": "1.3.13",
       "resolved": "https://registry.npmjs.org/flumeview-reduce/-/flumeview-reduce-1.3.13.tgz",
       "integrity": "sha512-QN/07+ia3uXpfy8/xWjLI2XGIG67Aiwp9VaOTIqYt6NHP6OfdGfl8nGRPkJRHlkfFbzEouRvJcQBFohWEXMdNQ==",
+      "dev": true,
       "requires": {
         "async-single": "1.0.5",
         "atomic-file": "1.1.5",
@@ -2925,11 +2931,6 @@
         }
       }
     },
-    "pull-iterable": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/pull-iterable/-/pull-iterable-0.1.0.tgz",
-      "integrity": "sha512-FjhQ/STYNGwQaBhmuiZspL/+PIj+OHB1lE9OteegEWzciQhkJPx6Fwt+jqcpRDJ3kTzpt/ETSo3M5TFRpZ0pgQ=="
-    },
     "pull-level": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
@@ -3005,6 +3006,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pull-notify/-/pull-notify-0.1.1.tgz",
       "integrity": "sha1-b4b/ldJwuJw+vyVbYDG3Ay3JnMo=",
+      "dev": true,
       "requires": {
         "pull-pushable": "2.2.0"
       }
@@ -3419,18 +3421,6 @@
         "libnested": "1.3.2",
         "mutant": "3.22.1",
         "pull-defer": "0.2.2"
-      }
-    },
-    "scuttle-invite-db": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/scuttle-invite-db/-/scuttle-invite-db-0.0.7.tgz",
-      "integrity": "sha512-2tNnkCWqQvF9kZUKpHVhjfD7QWh/FB5XYIMBZ8oTaX0QBwoKVx9DTfomM6W/P5lYoIUL61OjTMGX/xsEQwZb3w==",
-      "requires": {
-        "flumeview-reduce": "1.3.13",
-        "pull-defer": "0.2.2",
-        "pull-iterable": "0.1.0",
-        "scuttle-invite-schema": "0.0.8",
-        "ssb-msg-content": "1.0.1"
       }
     },
     "scuttle-invite-schema": {
@@ -3958,23 +3948,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
-    },
-    "ssb-backlinks": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/ssb-backlinks/-/ssb-backlinks-0.6.1.tgz",
-      "integrity": "sha1-LJfqNp42b/uCF3WscKjX8ffVMIU=",
-      "requires": {
-        "base64-url": "1.3.3",
-        "deep-equal": "1.0.1",
-        "flumeview-level": "2.1.1",
-        "flumeview-query": "3.0.7",
-        "map-filter-reduce": "3.1.0",
-        "pull-flatmap": "0.0.1",
-        "pull-stream": "3.6.8",
-        "ssb-keys": "7.0.16",
-        "ssb-ref": "2.11.1",
-        "xtend": "4.0.1"
-      }
     },
     "ssb-blobs": {
       "version": "1.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -595,8 +595,7 @@
     "charwise": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/charwise/-/charwise-3.0.1.tgz",
-      "integrity": "sha512-RcdumNsM6fJZ5HHbYunqj2bpurVRGsXour3OR+SlLEHFhG6ALm54i6Osnh+OvO7kEoSBzwExpblYFH8zKQiEPw==",
-      "dev": true
+      "integrity": "sha512-RcdumNsM6fJZ5HHbYunqj2bpurVRGsXour3OR+SlLEHFhG6ALm54i6Osnh+OvO7kEoSBzwExpblYFH8zKQiEPw=="
     },
     "chloride": {
       "version": "2.2.10",
@@ -814,8 +813,7 @@
     "deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-      "dev": true
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -943,7 +941,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-4.0.1.tgz",
       "integrity": "sha512-AlSE+ugBIpLL0i9if2SlnOZ4oWj/XvBb8tw2Ie/pFB73vdYs5O/6plRyqIgjbZbz8onaL20AAuMP87LWbP56IQ==",
-      "dev": true,
       "requires": {
         "abstract-leveldown": "^4.0.0",
         "level-codec": "^8.0.0",
@@ -955,7 +952,6 @@
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
           "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
-          "dev": true,
           "requires": {
             "xtend": "~4.0.0"
           }
@@ -963,8 +959,7 @@
         "level-codec": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-8.0.0.tgz",
-          "integrity": "sha512-gNZlo1HRHz0BWxzGCyNf7xntAs2HKOPvvRBWtXsoDvEX4vMYnSTBS6ZnxoaiX7nhxSBPpegRa8CQ/hnfGBKk3Q==",
-          "dev": true
+          "integrity": "sha512-gNZlo1HRHz0BWxzGCyNf7xntAs2HKOPvvRBWtXsoDvEX4vMYnSTBS6ZnxoaiX7nhxSBPpegRa8CQ/hnfGBKk3Q=="
         }
       }
     },
@@ -3106,8 +3101,7 @@
     "opencollective-postinstall": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.0.tgz",
-      "integrity": "sha512-XAe80GycLe2yRGnJsUtt+EO5lk06XYRQt4kJJe53O2kJHPZJOZ+XMF/b47HW96e6LhfKVpwnXVr/s56jhV98jg==",
-      "dev": true
+      "integrity": "sha512-XAe80GycLe2yRGnJsUtt+EO5lk06XYRQt4kJJe53O2kJHPZJOZ+XMF/b47HW96e6LhfKVpwnXVr/s56jhV98jg=="
     },
     "options": {
       "version": "0.0.6",
@@ -4473,6 +4467,171 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "ssb-backlinks": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/ssb-backlinks/-/ssb-backlinks-0.7.3.tgz",
+      "integrity": "sha512-84s5phSVyZsYV0FTmBJvICPgOMuu8ouzukG8Gz2XtuOui95GBP/G7UIBURgYVS82XA6g9xPA/jf38fsMxid38Q==",
+      "requires": {
+        "base64-url": "^2.2.0",
+        "deep-equal": "^1.0.1",
+        "flumeview-query": "^6.2.0",
+        "pull-stream": "^3.6.7",
+        "ssb-keys": "^7.0.14",
+        "ssb-ref": "^2.9.0",
+        "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
+          "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
+          "requires": {
+            "xtend": "~4.0.0"
+          }
+        },
+        "base64-url": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-2.2.0.tgz",
+          "integrity": "sha512-Y4qHHAE+rWjmAFPQmHPiiD+hWwM/XvuFLlP6kVxlwZJK7rjiE2uIQR9tZ37iEr1E6iCj9799yxMAmiXzITb3lQ=="
+        },
+        "bindings": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+          "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+        },
+        "deferred-leveldown": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-3.0.0.tgz",
+          "integrity": "sha512-ajbXqRPMXRlcdyt0TuWqknOJkp1JgQjGB7xOl2V+ebol7/U11E9h3/nCZAtN1M7djmAJEIhypCUc1tIWxdQAuQ==",
+          "requires": {
+            "abstract-leveldown": "~4.0.0"
+          }
+        },
+        "flumeview-level": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/flumeview-level/-/flumeview-level-3.0.5.tgz",
+          "integrity": "sha512-LKW+YdJGemOo7TnUwpFHq4cBBiYAIKtWk+G2CK7zrxbCIiAHemBRudohBOUKuSUZZ0CReR5fJ73peBHW02VerA==",
+          "requires": {
+            "charwise": "^3.0.1",
+            "explain-error": "^1.0.4",
+            "level": "^3.0.1",
+            "ltgt": "^2.1.3",
+            "mkdirp": "^0.5.1",
+            "obv": "0.0.0",
+            "pull-level": "^2.0.3",
+            "pull-paramap": "^1.2.1",
+            "pull-stream": "^3.5.0",
+            "pull-write": "^1.1.1"
+          }
+        },
+        "flumeview-query": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/flumeview-query/-/flumeview-query-6.2.0.tgz",
+          "integrity": "sha512-tq7rD63gixBDOPegw10khz/d5Bnq9qW9IbURHbWuJkG5CUBm3JP4QQSIF/Phl99jz66MRuXoXjRrXXQLN89iNQ==",
+          "requires": {
+            "deep-equal": "^1.0.1",
+            "flumeview-level": "^3.0.0",
+            "map-filter-reduce": "^3.0.7",
+            "pull-flatmap": "0.0.1",
+            "pull-paramap": "^1.1.3",
+            "pull-sink-through": "0.0.0",
+            "pull-stream": "^3.4.0"
+          }
+        },
+        "level": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/level/-/level-3.0.2.tgz",
+          "integrity": "sha512-2qYbbiptPsPWGUI+AgB1gTNXqIjPpALRqrQyNx1zWYNZxhhuzEj/IE4Unu9weEBnsUEocfYe56xOGlAceb8/Fg==",
+          "requires": {
+            "level-packager": "^2.0.2",
+            "leveldown": "^3.0.0",
+            "opencollective-postinstall": "^2.0.0"
+          }
+        },
+        "level-errors": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.1.2.tgz",
+          "integrity": "sha512-Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==",
+          "requires": {
+            "errno": "~0.1.1"
+          }
+        },
+        "level-iterator-stream": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
+          "integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
+          "requires": {
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.5",
+            "xtend": "^4.0.0"
+          }
+        },
+        "level-packager": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-2.1.1.tgz",
+          "integrity": "sha512-6l3G6dVkmdvHwOJrEA9d9hL6SSFrzwjQoLP8HsvohOgfY/8Z9LyTKNCM5Gc84wtsUWCuIHu6r+S6WrCtTWUJCw==",
+          "requires": {
+            "encoding-down": "~4.0.0",
+            "levelup": "^2.0.0"
+          }
+        },
+        "leveldown": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-3.0.2.tgz",
+          "integrity": "sha512-+ANRScj1npQQzv6e4DYAKRjVQZZ+ahMoubKrNP68nIq+l9bYgb+WiXF+14oTcQTg2f7qE9WHGW7rBG9nGSsA+A==",
+          "requires": {
+            "abstract-leveldown": "~4.0.0",
+            "bindings": "~1.3.0",
+            "fast-future": "~1.0.2",
+            "nan": "~2.10.0",
+            "prebuild-install": "^4.0.0"
+          }
+        },
+        "levelup": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/levelup/-/levelup-2.0.2.tgz",
+          "integrity": "sha512-us+nTLUyd/eLnclYYddOCdAVw1hnymGx/9p4Jr5ThohStsjLqMVmbYiz6/SYFZEPXNF+AKQSvh6fA2e2KZpC8w==",
+          "requires": {
+            "deferred-leveldown": "~3.0.0",
+            "level-errors": "~1.1.0",
+            "level-iterator-stream": "~2.0.0",
+            "xtend": "~4.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "nan": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+        },
+        "prebuild-install": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
+          "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
+          "requires": {
+            "detect-libc": "^1.0.3",
+            "expand-template": "^1.0.2",
+            "github-from-package": "0.0.0",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "node-abi": "^2.2.0",
+            "noop-logger": "^0.1.1",
+            "npmlog": "^4.0.1",
+            "os-homedir": "^1.0.1",
+            "pump": "^2.0.1",
+            "rc": "^1.1.6",
+            "simple-get": "^2.7.0",
+            "tar-fs": "^1.13.0",
+            "tunnel-agent": "^0.6.0",
+            "which-pm-runs": "^1.0.0"
+          }
+        }
+      }
     },
     "ssb-blobs": {
       "version": "1.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
       "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
       "requires": {
-        "xtend": "~4.0.0"
+        "xtend": "4.0.1"
       }
     },
     "aligned-block-file": {
@@ -18,11 +18,11 @@
       "integrity": "sha512-ai/S+nZ9XMjC0ReZfq94OLGCICVBJyhNiKWmF1J+/GVZZaXtYV805plMi9obaWjfNl/QljB+VOsT+wQ7R858xA==",
       "dev": true,
       "requires": {
-        "hashlru": "^2.1.0",
-        "int53": "^0.2.4",
-        "mkdirp": "^0.5.1",
+        "hashlru": "2.2.1",
+        "int53": "0.2.4",
+        "mkdirp": "0.5.1",
         "obv": "0.0.0",
-        "uint48be": "^1.0.1"
+        "uint48be": "1.0.2"
       }
     },
     "ansi-escapes": {
@@ -47,8 +47,8 @@
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "micromatch": "^2.1.5",
-        "normalize-path": "^2.0.0"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       }
     },
     "append-batch": {
@@ -67,8 +67,8 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.6"
       }
     },
     "argparse": {
@@ -77,7 +77,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -86,7 +86,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.0.1"
+        "arr-flatten": "1.1.0"
       }
     },
     "arr-flatten": {
@@ -101,7 +101,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -152,7 +152,7 @@
       "integrity": "sha1-KPUTk92LuL2q2XI0JRm/CWIaNaM=",
       "dev": true,
       "requires": {
-        "unherit": "^1.0.0"
+        "unherit": "1.1.1"
       }
     },
     "babel-code-frame": {
@@ -160,9 +160,9 @@
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       }
     },
     "babel-core": {
@@ -170,25 +170,25 @@
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
       "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-generator": "^6.26.0",
-        "babel-helpers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "convert-source-map": "^1.5.1",
-        "debug": "^2.6.9",
-        "json5": "^0.5.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.4",
-        "path-is-absolute": "^1.0.1",
-        "private": "^0.1.8",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.7"
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.1",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.5.1",
+        "debug": "2.6.9",
+        "json5": "0.5.1",
+        "lodash": "4.17.10",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
       }
     },
     "babel-generator": {
@@ -196,14 +196,14 @@
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "requires": {
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "detect-indent": "^4.0.0",
-        "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
-        "source-map": "^0.5.7",
-        "trim-right": "^1.0.1"
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.10",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       }
     },
     "babel-helper-call-delegate": {
@@ -211,10 +211,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-get-function-arity": {
@@ -222,8 +222,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-hoist-variables": {
@@ -231,8 +231,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helpers": {
@@ -240,8 +240,8 @@
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-messages": {
@@ -249,7 +249,7 @@
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -257,7 +257,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -265,7 +265,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -273,11 +273,11 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.10"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -285,8 +285,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -294,7 +294,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -302,12 +302,12 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "requires": {
-        "babel-helper-call-delegate": "^6.24.1",
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-call-delegate": "6.24.1",
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -315,8 +315,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -324,7 +324,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -332,7 +332,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-preset-es2040": {
@@ -340,15 +340,15 @@
       "resolved": "https://registry.npmjs.org/babel-preset-es2040/-/babel-preset-es2040-1.1.1.tgz",
       "integrity": "sha1-QIzDNyRwggXHgGZ7kw+njfW8j5Q=",
       "requires": {
-        "babel-plugin-check-es2015-constants": "^6.8.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.8.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.9.0",
-        "babel-plugin-transform-es2015-computed-properties": "^6.8.0",
-        "babel-plugin-transform-es2015-destructuring": "^6.9.0",
-        "babel-plugin-transform-es2015-parameters": "^6.9.0",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.8.0",
-        "babel-plugin-transform-es2015-spread": "^6.8.0",
-        "babel-plugin-transform-es2015-template-literals": "^6.8.0"
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0"
       }
     },
     "babel-register": {
@@ -356,13 +356,13 @@
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "requires": {
-        "babel-core": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.15"
+        "babel-core": "6.26.3",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.7",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.10",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
       }
     },
     "babel-runtime": {
@@ -370,8 +370,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.11.1"
       }
     },
     "babel-template": {
@@ -379,11 +379,11 @@
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.10"
       }
     },
     "babel-traverse": {
@@ -391,15 +391,15 @@
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.10"
       }
     },
     "babel-types": {
@@ -407,10 +407,10 @@
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.10",
+        "to-fast-properties": "1.0.3"
       }
     },
     "babylon": {
@@ -461,8 +461,8 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2"
       }
     },
     "blake2s": {
@@ -476,7 +476,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -486,9 +486,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
       }
     },
     "broadcast-stream": {
@@ -507,8 +507,8 @@
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "requires": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
+        "buffer-alloc-unsafe": "1.1.0",
+        "buffer-fill": "1.0.0"
       }
     },
     "buffer-alloc-unsafe": {
@@ -532,8 +532,8 @@
       "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
       "integrity": "sha1-HRPL/3F65xWAlKqIGzXQgbOHJT4=",
       "requires": {
-        "bytewise-core": "^1.2.2",
-        "typewise": "^1.0.3"
+        "bytewise-core": "1.2.3",
+        "typewise": "1.0.3"
       }
     },
     "bytewise-core": {
@@ -541,7 +541,7 @@
       "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
       "integrity": "sha1-P7QQx+kVWOsasiqCg0V3qmvWHUI=",
       "requires": {
-        "typewise-core": "^1.2"
+        "typewise-core": "1.2.0"
       }
     },
     "camelcase": {
@@ -561,11 +561,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       }
     },
     "character-entities": {
@@ -602,11 +602,11 @@
       "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.2.10.tgz",
       "integrity": "sha512-CbU1ISGiB2JBV6PDXx7hkl8D94d2TPD1BANUMFbr8rZYKJi8De2d3Hu2XDIOLAhXf+8yhoFOdjtLG6fxz3QByQ==",
       "requires": {
-        "is-electron": "^2.0.0",
-        "sodium-browserify": "^1.2.4",
-        "sodium-browserify-tweetnacl": "^0.2.2",
-        "sodium-chloride": "^1.1.0",
-        "sodium-native": "^2.1.6"
+        "is-electron": "2.1.0",
+        "sodium-browserify": "1.2.4",
+        "sodium-browserify-tweetnacl": "0.2.3",
+        "sodium-chloride": "1.1.0",
+        "sodium-native": "2.1.6"
       }
     },
     "chloride-test": {
@@ -614,7 +614,7 @@
       "resolved": "https://registry.npmjs.org/chloride-test/-/chloride-test-1.2.2.tgz",
       "integrity": "sha1-F4aGqF6SeARREulujHkXk/mhCuo=",
       "requires": {
-        "json-buffer": "^2.0.11"
+        "json-buffer": "2.0.11"
       }
     },
     "chokidar": {
@@ -623,15 +623,14 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "^1.3.0",
-        "async-each": "^1.0.0",
-        "fsevents": "^1.0.0",
-        "glob-parent": "^2.0.0",
-        "inherits": "^2.0.1",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^2.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0"
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.1",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
       }
     },
     "chownr": {
@@ -645,7 +644,7 @@
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^1.0.1"
+        "restore-cursor": "1.0.1"
       }
     },
     "co": {
@@ -682,10 +681,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.1.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
       },
       "dependencies": {
         "inherits": {
@@ -707,9 +706,9 @@
       "integrity": "sha1-aHTx6TX8qZ0EjK6qrZoK6wILzOA=",
       "dev": true,
       "requires": {
-        "continuable": "~1.2.0",
-        "continuable-para": "~1.2.0",
-        "continuable-series": "~1.2.0"
+        "continuable": "1.2.0",
+        "continuable-para": "1.2.0",
+        "continuable-series": "1.2.0"
       }
     },
     "continuable": {
@@ -724,7 +723,7 @@
       "integrity": "sha1-gcdNQXcdjJJ4Ph4A5fEbNNbfx4w=",
       "dev": true,
       "requires": {
-        "continuable": "~1.1.6"
+        "continuable": "1.1.8"
       },
       "dependencies": {
         "continuable": {
@@ -741,7 +740,7 @@
       "integrity": "sha1-h88G7FgHFuEN/5X7C4TF8OisrF8=",
       "dev": true,
       "requires": {
-        "continuable": "~1.1.6"
+        "continuable": "1.1.8"
       },
       "dependencies": {
         "continuable": {
@@ -758,8 +757,8 @@
       "integrity": "sha1-RFUQ9klFndD8NchyAVFGEicxxYM=",
       "dev": true,
       "requires": {
-        "continuable-hash": "~0.1.4",
-        "continuable-list": "~0.1.5"
+        "continuable-hash": "0.1.4",
+        "continuable-list": "0.1.6"
       }
     },
     "continuable-series": {
@@ -789,9 +788,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "lru-cache": "4.1.3",
+        "shebang-command": "1.2.0",
+        "which": "1.3.1"
       }
     },
     "debug": {
@@ -807,7 +806,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "1.0.0"
       }
     },
     "deep-equal": {
@@ -825,7 +824,7 @@
       "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
       "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
       "requires": {
-        "abstract-leveldown": "~2.6.0"
+        "abstract-leveldown": "2.6.3"
       }
     },
     "define-properties": {
@@ -834,8 +833,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
       },
       "dependencies": {
         "object-keys": {
@@ -862,7 +861,7 @@
       "resolved": "https://registry.npmjs.org/depject/-/depject-4.1.1.tgz",
       "integrity": "sha1-6/ciCGgsEfx9BRIjxG6223jVYFg=",
       "requires": {
-        "libnested": "^1.1.0"
+        "libnested": "1.3.2"
       }
     },
     "depnest": {
@@ -870,8 +869,8 @@
       "resolved": "https://registry.npmjs.org/depnest/-/depnest-1.3.0.tgz",
       "integrity": "sha1-FL2KNh30RdLTT37LNi1sdFcoiVk=",
       "requires": {
-        "es2040": "^1.2.3",
-        "libnested": "^1.2.1"
+        "es2040": "1.2.6",
+        "libnested": "1.3.2"
       }
     },
     "detab": {
@@ -880,7 +879,7 @@
       "integrity": "sha1-AbwqSr57x8xnwwOYCO265HBJoO4=",
       "dev": true,
       "requires": {
-        "repeat-string": "^1.5.2"
+        "repeat-string": "1.6.1"
       }
     },
     "detect-indent": {
@@ -888,7 +887,7 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "detect-libc": {
@@ -913,7 +912,7 @@
       "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.1.4.tgz",
       "integrity": "sha1-lKRCSLuH2jXbDv968KpXYWgRf1k=",
       "requires": {
-        "tweetnacl": "0.x.x"
+        "tweetnacl": "0.14.5"
       }
     },
     "elegant-spinner": {
@@ -934,7 +933,7 @@
       "integrity": "sha1-0GPP7prxGMxa7vvC6bPdUIWBXGM=",
       "dev": true,
       "requires": {
-        "emoji-named-characters": "~1.0.2"
+        "emoji-named-characters": "1.0.2"
       }
     },
     "encoding-down": {
@@ -942,10 +941,10 @@
       "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-4.0.1.tgz",
       "integrity": "sha512-AlSE+ugBIpLL0i9if2SlnOZ4oWj/XvBb8tw2Ie/pFB73vdYs5O/6plRyqIgjbZbz8onaL20AAuMP87LWbP56IQ==",
       "requires": {
-        "abstract-leveldown": "^4.0.0",
-        "level-codec": "^8.0.0",
-        "level-errors": "^1.0.4",
-        "xtend": "^4.0.1"
+        "abstract-leveldown": "4.0.3",
+        "level-codec": "8.0.0",
+        "level-errors": "1.0.5",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -953,7 +952,7 @@
           "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
           "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
           "requires": {
-            "xtend": "~4.0.0"
+            "xtend": "4.0.1"
           }
         },
         "level-codec": {
@@ -968,7 +967,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "epidemic-broadcast-trees": {
@@ -977,8 +976,8 @@
       "integrity": "sha512-yNbiNBGgX69SleCvOeNL9v7DlqtcEeH6FXZOnGCSgsgcJIZQIMwsQ1HB/j7h+yvnYYh/qqX2iFP9fqR0aukuug==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.3",
-        "push-stream": "^10.0.0"
+        "inherits": "2.0.3",
+        "push-stream": "10.0.3"
       },
       "dependencies": {
         "inherits": {
@@ -994,7 +993,7 @@
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "requires": {
-        "prr": "~1.0.1"
+        "prr": "1.0.1"
       }
     },
     "es-abstract": {
@@ -1003,11 +1002,11 @@
       "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.1.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.3",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
       }
     },
     "es-to-primitive": {
@@ -1016,9 +1015,9 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.1",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.1"
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
       }
     },
     "es2040": {
@@ -1026,9 +1025,9 @@
       "resolved": "https://registry.npmjs.org/es2040/-/es2040-1.2.6.tgz",
       "integrity": "sha512-+sAm7CSGH2+0NMZqm63huevZVoyk8OwF8lVIdwPcNtvZxX3YIITGiui8bfLYS8oNcgCgHNYO+QsgMafwo1OWwg==",
       "requires": {
-        "babel-core": "^6.9.1",
-        "babel-preset-es2040": "^1.1.0",
-        "through2": "^2.0.1"
+        "babel-core": "6.26.3",
+        "babel-preset-es2040": "1.1.1",
+        "through2": "2.0.3"
       }
     },
     "escape-string-regexp": {
@@ -1065,7 +1064,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "^0.1.0"
+        "is-posix-bracket": "0.1.1"
       }
     },
     "expand-range": {
@@ -1074,7 +1073,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "^2.1.0"
+        "fill-range": "2.2.4"
       }
     },
     "expand-template": {
@@ -1105,7 +1104,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "fast-future": {
@@ -1119,8 +1118,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
       }
     },
     "filename-regex": {
@@ -1135,11 +1134,11 @@
       "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "dev": true,
       "requires": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^3.0.0",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "3.0.0",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
       }
     },
     "flumecodec": {
@@ -1148,7 +1147,7 @@
       "integrity": "sha1-Ns4Gq+Lg4BxE3WnyoWUwWiMgZJs=",
       "dev": true,
       "requires": {
-        "level-codec": "^6.2.0"
+        "level-codec": "6.2.0"
       },
       "dependencies": {
         "level-codec": {
@@ -1165,12 +1164,12 @@
       "integrity": "sha512-R6em/DjNiUBU2H8LYt9Q66+jaQy0FHYReXy52UgbUh03VI307OXXvq+fJ5Vt90dfnECSpB9S8a8+3qErGJzLPw==",
       "dev": true,
       "requires": {
-        "cont": "^1.0.3",
-        "explain-error": "^1.0.3",
+        "cont": "1.0.3",
+        "explain-error": "1.0.4",
         "obv": "0.0.1",
         "pull-cont": "0.0.0",
-        "pull-looper": "^1.0.0",
-        "pull-stream": "^3.5.0"
+        "pull-looper": "1.0.0",
+        "pull-stream": "3.6.8"
       },
       "dependencies": {
         "obv": {
@@ -1187,17 +1186,17 @@
       "integrity": "sha512-4yYdr8tTL0qOkKqhxAxvNnIwDBaBcLEsJWbyc2wU4Ycaewts9xxcBaxNbORp2KBbTwFaqZAV13HVpfZcO1X/AA==",
       "dev": true,
       "requires": {
-        "aligned-block-file": "^1.1.2",
-        "append-batch": "^0.0.1",
-        "explain-error": "^1.0.3",
-        "hashlru": "^2.2.0",
-        "int53": "^0.2.4",
-        "looper": "^4.0.0",
-        "ltgt": "^2.1.3",
+        "aligned-block-file": "1.1.3",
+        "append-batch": "0.0.1",
+        "explain-error": "1.0.4",
+        "hashlru": "2.2.1",
+        "int53": "0.2.4",
+        "looper": "4.0.0",
+        "ltgt": "2.2.1",
         "obv": "0.0.1",
-        "pull-cursor": "^3.0.0",
-        "pull-looper": "^1.0.0",
-        "uint48be": "^1.0.1"
+        "pull-cursor": "3.0.0",
+        "pull-looper": "1.0.0",
+        "uint48be": "1.0.2"
       },
       "dependencies": {
         "looper": {
@@ -1220,10 +1219,10 @@
       "integrity": "sha1-0qn6Fkn1fvaNG4nrTEO/sXJDeWc=",
       "dev": true,
       "requires": {
-        "async-single": "^1.0.5",
-        "atomic-file": "^1.1.3",
+        "async-single": "1.0.5",
+        "atomic-file": "1.1.5",
         "obv": "0.0.1",
-        "pull-stream": "^3.6.0"
+        "pull-stream": "3.6.8"
       },
       "dependencies": {
         "obv": {
@@ -1239,16 +1238,16 @@
       "resolved": "https://registry.npmjs.org/flumeview-level/-/flumeview-level-2.1.1.tgz",
       "integrity": "sha1-KQkSRgKzKdT2oOuMkDigyRFrNoE=",
       "requires": {
-        "bytewise": "^1.1.0",
-        "explain-error": "^1.0.4",
-        "level": "^1.7.0",
-        "ltgt": "^2.1.3",
-        "mkdirp": "^0.5.1",
+        "bytewise": "1.1.0",
+        "explain-error": "1.0.4",
+        "level": "1.7.0",
+        "ltgt": "2.2.1",
+        "mkdirp": "0.5.1",
         "obv": "0.0.0",
-        "pull-level": "^2.0.3",
-        "pull-paramap": "^1.2.1",
-        "pull-stream": "^3.5.0",
-        "pull-write": "^1.1.1"
+        "pull-level": "2.0.4",
+        "pull-paramap": "1.2.2",
+        "pull-stream": "3.6.8",
+        "pull-write": "1.1.4"
       }
     },
     "flumeview-query": {
@@ -1256,13 +1255,13 @@
       "resolved": "https://registry.npmjs.org/flumeview-query/-/flumeview-query-3.0.7.tgz",
       "integrity": "sha1-52wNcuxF5irrqho2yUYeHHbOgqA=",
       "requires": {
-        "explain-error": "^1.0.1",
-        "flumeview-level": "^2.1.0",
-        "map-filter-reduce": "^3.0.2",
+        "explain-error": "1.0.4",
+        "flumeview-level": "2.1.1",
+        "map-filter-reduce": "3.1.0",
         "pull-flatmap": "0.0.1",
-        "pull-paramap": "^1.1.3",
+        "pull-paramap": "1.2.2",
         "pull-sink-through": "0.0.0",
-        "pull-stream": "^3.4.0"
+        "pull-stream": "3.6.8"
       }
     },
     "flumeview-reduce": {
@@ -1271,13 +1270,13 @@
       "integrity": "sha512-QN/07+ia3uXpfy8/xWjLI2XGIG67Aiwp9VaOTIqYt6NHP6OfdGfl8nGRPkJRHlkfFbzEouRvJcQBFohWEXMdNQ==",
       "dev": true,
       "requires": {
-        "async-single": "^1.0.5",
-        "atomic-file": "^1.1.3",
-        "deep-equal": "^1.0.1",
+        "async-single": "1.0.5",
+        "atomic-file": "1.1.5",
+        "deep-equal": "1.0.1",
         "flumecodec": "0.0.0",
         "obv": "0.0.0",
-        "pull-notify": "^0.1.1",
-        "pull-stream": "^3.5.0"
+        "pull-notify": "0.1.1",
+        "pull-stream": "3.6.8"
       }
     },
     "for-each": {
@@ -1286,7 +1285,7 @@
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.3"
+        "is-callable": "1.1.3"
       }
     },
     "for-in": {
@@ -1301,7 +1300,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
     },
     "foreach": {
@@ -1321,542 +1320,6 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "fs-minipass": {
-          "version": "1.2.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "iconv-lite": {
-          "version": "0.4.21",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safer-buffer": "^2.1.0"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "minipass": {
-          "version": "2.2.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "nan": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-          "dev": true,
-          "optional": true
-        },
-        "needle": {
-          "version": "2.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.10.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "npm-packlist": {
-          "version": "1.1.10",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "glob": "^7.0.5"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "semver": {
-          "version": "5.5.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "4.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "^1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "yallist": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        }
-      }
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -1868,14 +1331,14 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.3"
       }
     },
     "generate-function": {
@@ -1888,7 +1351,7 @@
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "requires": {
-        "is-property": "^1.0.0"
+        "is-property": "1.0.2"
       }
     },
     "github-from-package": {
@@ -1902,12 +1365,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.1",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-base": {
@@ -1916,8 +1379,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "glob-parent": {
@@ -1926,7 +1389,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "^2.0.0"
+        "is-glob": "2.0.1"
       }
     },
     "globals": {
@@ -1940,12 +1403,12 @@
       "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "glob": "^6.0.1",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "6.0.4",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "glob": {
@@ -1954,11 +1417,11 @@
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.1",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -1975,7 +1438,7 @@
       "integrity": "sha1-v0QtCoeOg5AeXvPmUtI/+1uDHtc=",
       "dev": true,
       "requires": {
-        "statistics": "^3.3.0"
+        "statistics": "3.3.0"
       }
     },
     "has": {
@@ -1984,7 +1447,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -1992,7 +1455,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-network": {
@@ -2023,8 +1486,8 @@
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.1"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "hoox": {
@@ -2045,8 +1508,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -2070,7 +1533,7 @@
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.3.1"
       }
     },
     "ip": {
@@ -2096,8 +1559,8 @@
       "integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
       "dev": true,
       "requires": {
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0"
+        "is-alphabetical": "1.0.2",
+        "is-decimal": "1.0.2"
       }
     },
     "is-binary-path": {
@@ -2106,7 +1569,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-buffer": {
@@ -2150,7 +1613,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-primitive": "2.0.0"
       }
     },
     "is-extendable": {
@@ -2170,7 +1633,7 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -2178,7 +1641,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-glob": {
@@ -2187,7 +1650,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "is-hexadecimal": {
@@ -2206,11 +1669,11 @@
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
       "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
       "requires": {
-        "generate-function": "^2.0.0",
-        "generate-object-property": "^1.1.0",
-        "is-my-ip-valid": "^1.0.0",
-        "jsonpointer": "^4.0.0",
-        "xtend": "^4.0.0"
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "is-my-ip-valid": "1.0.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
       }
     },
     "is-number": {
@@ -2219,7 +1682,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-posix-bracket": {
@@ -2245,7 +1708,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has": "1.0.3"
       }
     },
     "is-symbol": {
@@ -2290,8 +1753,8 @@
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.0"
       }
     },
     "jsesc": {
@@ -2320,7 +1783,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "^1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "level": {
@@ -2328,8 +1791,8 @@
       "resolved": "https://registry.npmjs.org/level/-/level-1.7.0.tgz",
       "integrity": "sha1-Q0ZKOounOy895WokKSgFFG2iE6E=",
       "requires": {
-        "level-packager": "~1.2.0",
-        "leveldown": "~1.7.0"
+        "level-packager": "1.2.1",
+        "leveldown": "1.7.2"
       }
     },
     "level-codec": {
@@ -2342,7 +1805,7 @@
       "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
       "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
       "requires": {
-        "errno": "~0.1.1"
+        "errno": "0.1.7"
       }
     },
     "level-iterator-stream": {
@@ -2350,10 +1813,10 @@
       "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
       "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
       "requires": {
-        "inherits": "^2.0.1",
-        "level-errors": "^1.0.3",
-        "readable-stream": "^1.0.33",
-        "xtend": "^4.0.0"
+        "inherits": "2.0.1",
+        "level-errors": "1.0.5",
+        "readable-stream": "1.1.14",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -2366,10 +1829,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -2384,7 +1847,7 @@
       "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-1.2.1.tgz",
       "integrity": "sha1-Bn/t/Qcrf+PGvsYIDAy9SmsuEfQ=",
       "requires": {
-        "levelup": "~1.3.0"
+        "levelup": "1.3.9"
       }
     },
     "level-post": {
@@ -2392,7 +1855,7 @@
       "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
       "integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
       "requires": {
-        "ltgt": "^2.1.2"
+        "ltgt": "2.2.1"
       }
     },
     "level-sublevel": {
@@ -2401,14 +1864,14 @@
       "integrity": "sha512-+hptqmFYPKFju9QG4F6scvx3ZXkhrSmmhYui+hPzRn/jiC3DJ6VNZRKsIhGMpeajVBWfRV7XiysUThrJ/7PgXQ==",
       "dev": true,
       "requires": {
-        "bytewise": "~1.1.0",
-        "levelup": "~0.19.0",
-        "ltgt": "~2.1.1",
-        "pull-defer": "^0.2.2",
-        "pull-level": "^2.0.3",
-        "pull-stream": "^3.6.8",
-        "typewiselite": "~1.0.0",
-        "xtend": "~4.0.0"
+        "bytewise": "1.1.0",
+        "levelup": "0.19.1",
+        "ltgt": "2.1.3",
+        "pull-defer": "0.2.2",
+        "pull-level": "2.0.4",
+        "pull-stream": "3.6.8",
+        "typewiselite": "1.0.0",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -2417,7 +1880,7 @@
           "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
           "dev": true,
           "requires": {
-            "xtend": "~3.0.0"
+            "xtend": "3.0.0"
           },
           "dependencies": {
             "xtend": {
@@ -2434,7 +1897,7 @@
           "integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
           "dev": true,
           "requires": {
-            "readable-stream": "~1.0.26"
+            "readable-stream": "1.0.34"
           }
         },
         "deferred-leveldown": {
@@ -2443,7 +1906,7 @@
           "integrity": "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ=",
           "dev": true,
           "requires": {
-            "abstract-leveldown": "~0.12.1"
+            "abstract-leveldown": "0.12.4"
           }
         },
         "isarray": {
@@ -2458,13 +1921,13 @@
           "integrity": "sha1-86anIFJyxLXzXkEv8ASgOgrt9Qs=",
           "dev": true,
           "requires": {
-            "bl": "~0.8.1",
-            "deferred-leveldown": "~0.2.0",
-            "errno": "~0.1.1",
-            "prr": "~0.0.0",
-            "readable-stream": "~1.0.26",
-            "semver": "~5.1.0",
-            "xtend": "~3.0.0"
+            "bl": "0.8.2",
+            "deferred-leveldown": "0.2.0",
+            "errno": "0.1.7",
+            "prr": "0.0.0",
+            "readable-stream": "1.0.34",
+            "semver": "5.1.1",
+            "xtend": "3.0.0"
           },
           "dependencies": {
             "xtend": {
@@ -2493,10 +1956,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "semver": {
@@ -2518,11 +1981,11 @@
       "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.7.2.tgz",
       "integrity": "sha1-XjRnuyfuJGpKe429j7KxYgam64s=",
       "requires": {
-        "abstract-leveldown": "~2.6.1",
-        "bindings": "~1.2.1",
-        "fast-future": "~1.0.2",
-        "nan": "~2.6.1",
-        "prebuild-install": "^2.1.0"
+        "abstract-leveldown": "2.6.3",
+        "bindings": "1.2.1",
+        "fast-future": "1.0.2",
+        "nan": "2.6.2",
+        "prebuild-install": "2.5.3"
       }
     },
     "levelup": {
@@ -2530,13 +1993,13 @@
       "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
       "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
       "requires": {
-        "deferred-leveldown": "~1.2.1",
-        "level-codec": "~7.0.0",
-        "level-errors": "~1.0.3",
-        "level-iterator-stream": "~1.3.0",
-        "prr": "~1.0.1",
-        "semver": "~5.4.1",
-        "xtend": "~4.0.0"
+        "deferred-leveldown": "1.2.2",
+        "level-codec": "7.0.1",
+        "level-errors": "1.0.5",
+        "level-iterator-stream": "1.3.1",
+        "prr": "1.0.1",
+        "semver": "5.4.1",
+        "xtend": "4.0.1"
       }
     },
     "libnested": {
@@ -2583,7 +2046,7 @@
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0"
+        "chalk": "1.1.3"
       }
     },
     "log-update": {
@@ -2592,8 +2055,8 @@
       "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^1.0.0",
-        "cli-cursor": "^1.0.2"
+        "ansi-escapes": "1.4.0",
+        "cli-cursor": "1.0.2"
       }
     },
     "longest-streak": {
@@ -2612,7 +2075,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "requires": {
-        "js-tokens": "^3.0.0"
+        "js-tokens": "3.0.2"
       }
     },
     "lossy-store": {
@@ -2621,8 +2084,8 @@
       "integrity": "sha1-Vi4qkgPYZh9g6HEt5Af72t8nXck=",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1",
-        "tape": "^4.6.3"
+        "mkdirp": "0.5.1",
+        "tape": "4.9.1"
       }
     },
     "lru-cache": {
@@ -2631,8 +2094,8 @@
       "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "dev": true,
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "ltgt": {
@@ -2645,10 +2108,10 @@
       "resolved": "https://registry.npmjs.org/map-filter-reduce/-/map-filter-reduce-3.1.0.tgz",
       "integrity": "sha512-os2GlG1lEWRSAvAb9iqfapQ0I1GRXSA+alSjQl0DB7XxNyDx2/VOVAEVhK7EMsqwDDCWNTBSstoo1roc7U5H0w==",
       "requires": {
-        "binary-search": "^1.2.0",
+        "binary-search": "1.3.3",
         "pull-sink-through": "0.0.0",
-        "pull-stream": "^3.4.3",
-        "typewiselite": "^1.0.0"
+        "pull-stream": "3.6.8",
+        "typewiselite": "1.0.0"
       }
     },
     "map-merge": {
@@ -2675,10 +2138,10 @@
       "integrity": "sha1-wEiRiDwoyDYC4dBrBaEQN+NZtMg=",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.0",
-        "remark": "^3.2.2",
-        "remark-html": "^2.0.2",
-        "word-wrap": "^1.1.0"
+        "minimist": "1.2.0",
+        "remark": "3.2.3",
+        "remark-html": "2.0.2",
+        "word-wrap": "1.2.3"
       },
       "dependencies": {
         "minimist": {
@@ -2695,19 +2158,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
       }
     },
     "mimic-response": {
@@ -2720,7 +2183,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -2753,22 +2216,22 @@
       "integrity": "sha1-4oTV5KlE5yS+4uOJbLMAfwaaQbs=",
       "dev": true,
       "requires": {
-        "blake2s": "~1.0.1",
-        "cont": "~1.0.1",
-        "explain-error": "~1.0.1",
-        "mkdirp": "~0.5.0",
-        "pull-cat": "^1.1.8",
-        "pull-defer": "^0.2.2",
-        "pull-file": "^0.5.0",
-        "pull-glob": "~1.0.6",
-        "pull-live": "^1.0.0",
-        "pull-notify": "^0.1.1",
-        "pull-paramap": "^1.2.2",
-        "pull-stream": "^3.6.2",
-        "pull-write-file": "^0.2.1",
-        "rc": "~0.5.4",
-        "rimraf": "~2.2.8",
-        "stream-to-pull-stream": "^1.7.2"
+        "blake2s": "1.0.1",
+        "cont": "1.0.3",
+        "explain-error": "1.0.4",
+        "mkdirp": "0.5.1",
+        "pull-cat": "1.1.11",
+        "pull-defer": "0.2.2",
+        "pull-file": "0.5.0",
+        "pull-glob": "1.0.7",
+        "pull-live": "1.0.1",
+        "pull-notify": "0.1.1",
+        "pull-paramap": "1.2.2",
+        "pull-stream": "3.6.8",
+        "pull-write-file": "0.2.4",
+        "rc": "0.5.5",
+        "rimraf": "2.2.8",
+        "stream-to-pull-stream": "1.7.2"
       },
       "dependencies": {
         "deep-extend": {
@@ -2783,7 +2246,7 @@
           "integrity": "sha1-s8pAUwbggvnUUoKIkzutsrZWNls=",
           "dev": true,
           "requires": {
-            "pull-utf8-decoder": "^1.0.2"
+            "pull-utf8-decoder": "1.0.2"
           }
         },
         "rc": {
@@ -2792,10 +2255,10 @@
           "integrity": "sha1-VBzDMA9GS23+ZDLXVvDy3T6esZk=",
           "dev": true,
           "requires": {
-            "deep-extend": "~0.2.5",
-            "ini": "~1.3.0",
-            "minimist": "~0.0.7",
-            "strip-json-comments": "0.1.x"
+            "deep-extend": "0.2.11",
+            "ini": "1.3.5",
+            "minimist": "0.0.8",
+            "strip-json-comments": "0.1.3"
           }
         },
         "rimraf": {
@@ -2818,8 +2281,8 @@
       "integrity": "sha512-hVaXryaqJ3vvKjRNcOCEadzgO99nR+haxlptswr3vRvgavbK/Y/I7/Nat12WIQno2/A8+nkbE+ZcrsN3UDbtQw==",
       "dev": true,
       "requires": {
-        "pull-stream": "^3.4.3",
-        "stream-to-pull-stream": "^1.7.0"
+        "pull-stream": "3.6.8",
+        "stream-to-pull-stream": "1.7.2"
       }
     },
     "multicb": {
@@ -2834,13 +2297,13 @@
       "integrity": "sha512-vyoVDqxiJabvepIKYN2+lYcPDcV5/de54kWXg1nYa1VK0NMJZ+gVIS6bLnQ9FmNzOxpCmVrVOkaQ0pMlMic5Ow==",
       "dev": true,
       "requires": {
-        "pull-cat": "~1.1.5",
-        "pull-stream": "^3.6.1",
-        "pull-ws": "^3.3.0",
-        "secret-handshake": "^1.1.12",
+        "pull-cat": "1.1.11",
+        "pull-stream": "3.6.8",
+        "pull-ws": "3.3.1",
+        "secret-handshake": "1.1.13",
         "separator-escape": "0.0.0",
         "socks": "1.1.9",
-        "stream-to-pull-stream": "^1.7.2"
+        "stream-to-pull-stream": "1.7.2"
       }
     },
     "mutant": {
@@ -2849,7 +2312,7 @@
       "integrity": "sha1-kEh1RvcAs8KKqApD0c99M48wdYE=",
       "requires": {
         "browser-split": "0.0.1",
-        "xtend": "^4.0.1"
+        "xtend": "4.0.1"
       }
     },
     "muxrpc": {
@@ -2858,11 +2321,11 @@
       "integrity": "sha1-JPfaBpvUYpsHfpk7BXeUKyaI6ug=",
       "dev": true,
       "requires": {
-        "explain-error": "^1.0.1",
-        "packet-stream": "~2.0.0",
-        "packet-stream-codec": "^1.1.1",
-        "pull-goodbye": "~0.0.1",
-        "pull-stream": "^3.2.3"
+        "explain-error": "1.0.4",
+        "packet-stream": "2.0.4",
+        "packet-stream-codec": "1.1.2",
+        "pull-goodbye": "0.0.2",
+        "pull-stream": "3.6.8"
       }
     },
     "muxrpc-validation": {
@@ -2871,8 +2334,8 @@
       "integrity": "sha1-zWUNFyAl/p0GQjCqs4ymMo3Rby8=",
       "dev": true,
       "requires": {
-        "pull-stream": "^2.28.3",
-        "zerr": "^1.0.1"
+        "pull-stream": "2.28.4",
+        "zerr": "1.0.4"
       },
       "dependencies": {
         "pull-stream": {
@@ -2881,7 +2344,7 @@
           "integrity": "sha1-fql0E8FhnCC8O9+eEOkTR7AyU+Q=",
           "dev": true,
           "requires": {
-            "pull-core": "~1.1.0"
+            "pull-core": "1.1.0"
           }
         }
       }
@@ -2892,10 +2355,10 @@
       "integrity": "sha1-Sum6mGq4JcSlwS/LccbaqB6rUVg=",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.0",
-        "pull-stream": "^2.28.3",
-        "stream-to-pull-stream": "^1.6.6",
-        "word-wrap": "^1.1.0"
+        "minimist": "1.2.0",
+        "pull-stream": "2.28.4",
+        "stream-to-pull-stream": "1.7.2",
+        "word-wrap": "1.2.3"
       },
       "dependencies": {
         "minimist": {
@@ -2910,7 +2373,7 @@
           "integrity": "sha1-fql0E8FhnCC8O9+eEOkTR7AyU+Q=",
           "dev": true,
           "requires": {
-            "pull-core": "~1.1.0"
+            "pull-core": "1.1.0"
           }
         }
       }
@@ -2921,9 +2384,9 @@
       "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
       "dev": true,
       "requires": {
-        "mkdirp": "~0.5.1",
-        "ncp": "~2.0.0",
-        "rimraf": "~2.4.0"
+        "mkdirp": "0.5.1",
+        "ncp": "2.0.0",
+        "rimraf": "2.4.5"
       },
       "dependencies": {
         "glob": {
@@ -2932,11 +2395,11 @@
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.1",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "rimraf": {
@@ -2945,7 +2408,7 @@
           "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
           "dev": true,
           "requires": {
-            "glob": "^6.0.1"
+            "glob": "6.0.4"
           }
         }
       }
@@ -2966,7 +2429,7 @@
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.1.tgz",
       "integrity": "sha512-pUlswqpHQ7zGPI9lGjZ4XDNIEUDbHxsltfIRb7dTnYdhgHWHOcB0MLZKLoCz6UMcGzSPG5wGl1HODZVQAUsH6w==",
       "requires": {
-        "semver": "^5.4.1"
+        "semver": "5.4.1"
       }
     },
     "node-gyp-build": {
@@ -2981,7 +2444,7 @@
       "integrity": "sha512-K9nTVFOGUOYutaG8ywiKpCdVu458RFxSgSJ0rribUxtf5iLM9B2+raFJgkID3p5op0+twmoQqFaPnu9KYz6qzg==",
       "dev": true,
       "requires": {
-        "ip": "^1.1.5"
+        "ip": "1.1.5"
       }
     },
     "noop-logger": {
@@ -2995,7 +2458,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "normalize-uri": {
@@ -3010,9 +2473,9 @@
       "integrity": "sha1-5hlFX3B0ulTMZtbQ033Z8b5ry8A=",
       "dev": true,
       "requires": {
-        "rc": "^1.1.0",
-        "shellsubstitute": "^1.1.0",
-        "untildify": "^2.1.0"
+        "rc": "1.2.8",
+        "shellsubstitute": "1.2.0",
+        "untildify": "2.1.0"
       }
     },
     "npmlog": {
@@ -3020,10 +2483,10 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
+        "are-we-there-yet": "1.1.5",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
       }
     },
     "number-is-nan": {
@@ -3048,8 +2511,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
       }
     },
     "observ": {
@@ -3064,7 +2527,7 @@
       "integrity": "sha1-ME6XyFrdpw7NfwjaRQZ475Dwtwc=",
       "dev": true,
       "requires": {
-        "observ": "~0.2.0"
+        "observ": "0.2.0"
       }
     },
     "obv": {
@@ -3089,7 +2552,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -3125,8 +2588,8 @@
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "packet-stream": {
@@ -3141,8 +2604,8 @@
       "integrity": "sha1-ebMC/BRM37tKtv66cEDmpdmcecc=",
       "dev": true,
       "requires": {
-        "pull-reader": "^1.2.4",
-        "pull-through": "^1.0.17"
+        "pull-reader": "1.2.9",
+        "pull-through": "1.0.18"
       }
     },
     "parse-entities": {
@@ -3151,12 +2614,12 @@
       "integrity": "sha512-5N9lmQ7tmxfXf+hO3X6KRG6w7uYO/HL9fHalSySTdyn63C3WNvTM/1R8tn1u1larNcEbo3Slcy2bsVDQqvEpUg==",
       "dev": true,
       "requires": {
-        "character-entities": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "character-reference-invalid": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
+        "character-entities": "1.2.2",
+        "character-entities-legacy": "1.1.2",
+        "character-reference-invalid": "1.1.2",
+        "is-alphanumerical": "1.0.2",
+        "is-decimal": "1.0.2",
+        "is-hexadecimal": "1.0.2"
       }
     },
     "parse-glob": {
@@ -3165,10 +2628,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "parse-ms": {
@@ -3206,7 +2669,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "plur": {
@@ -3215,7 +2678,7 @@
       "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
       "dev": true,
       "requires": {
-        "irregular-plurals": "^1.0.0"
+        "irregular-plurals": "1.4.0"
       }
     },
     "prebuild-install": {
@@ -3223,21 +2686,21 @@
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
       "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
       "requires": {
-        "detect-libc": "^1.0.3",
-        "expand-template": "^1.0.2",
+        "detect-libc": "1.0.3",
+        "expand-template": "1.1.1",
         "github-from-package": "0.0.0",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "node-abi": "^2.2.0",
-        "noop-logger": "^0.1.1",
-        "npmlog": "^4.0.1",
-        "os-homedir": "^1.0.1",
-        "pump": "^2.0.1",
-        "rc": "^1.1.6",
-        "simple-get": "^2.7.0",
-        "tar-fs": "^1.13.0",
-        "tunnel-agent": "^0.6.0",
-        "which-pm-runs": "^1.0.0"
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "node-abi": "2.4.1",
+        "noop-logger": "0.1.1",
+        "npmlog": "4.1.2",
+        "os-homedir": "1.0.2",
+        "pump": "2.0.1",
+        "rc": "1.2.8",
+        "simple-get": "2.8.1",
+        "tar-fs": "1.16.2",
+        "tunnel-agent": "0.6.0",
+        "which-pm-runs": "1.0.0"
       },
       "dependencies": {
         "minimist": {
@@ -3259,9 +2722,9 @@
       "integrity": "sha1-QlfCVt8/sLRR1q/6qwIYhBJpgdw=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.1",
-        "parse-ms": "^1.0.0",
-        "plur": "^1.0.0"
+        "is-finite": "1.0.2",
+        "parse-ms": "1.0.1",
+        "plur": "1.0.0"
       },
       "dependencies": {
         "plur": {
@@ -3282,7 +2745,7 @@
       "resolved": "https://registry.npmjs.org/private-box/-/private-box-0.2.1.tgz",
       "integrity": "sha1-HfBhr8pbMDnH/qrdDa8PVvB+PsA=",
       "requires": {
-        "chloride": "^2.2.1"
+        "chloride": "2.2.10"
       }
     },
     "process-nextick-args": {
@@ -3313,12 +2776,12 @@
       "integrity": "sha1-w+JAOY6rP1lRsu0QeMWYi/egork=",
       "dev": true,
       "requires": {
-        "chloride": "^2.2.7",
-        "increment-buffer": "~1.0.0",
-        "pull-reader": "^1.2.5",
-        "pull-stream": "^3.2.3",
-        "pull-through": "^1.0.18",
-        "split-buffer": "~1.0.0"
+        "chloride": "2.2.10",
+        "increment-buffer": "1.0.1",
+        "pull-reader": "1.2.9",
+        "pull-stream": "3.6.8",
+        "pull-through": "1.0.18",
+        "split-buffer": "1.0.0"
       }
     },
     "pull-cat": {
@@ -3344,9 +2807,9 @@
       "integrity": "sha512-95lZVSF2eSEdOmUtlOBaD9p5YOvlYeCr5FBv2ySqcj/4rpaXI6d8OH+zPHHjKAf58R8QXJRZuyfHkcCX8TZbAg==",
       "dev": true,
       "requires": {
-        "looper": "^4.0.0",
-        "ltgt": "^2.2.0",
-        "pull-stream": "^3.6.0"
+        "looper": "4.0.0",
+        "ltgt": "2.2.1",
+        "pull-stream": "3.6.8"
       },
       "dependencies": {
         "looper": {
@@ -3368,7 +2831,7 @@
       "integrity": "sha1-HdmHYF1jV6DSPB5Lgm95FaIVEpw=",
       "dev": true,
       "requires": {
-        "pull-utf8-decoder": "^1.0.2"
+        "pull-utf8-decoder": "1.0.2"
       }
     },
     "pull-flatmap": {
@@ -3382,10 +2845,10 @@
       "integrity": "sha1-8YT2p3KLtNlWQTdr6tafb2bfR80=",
       "dev": true,
       "requires": {
-        "pull-file": "^0.5.0",
-        "pull-stream": "^3.3.0",
-        "pull-traverse": "^1.0.3",
-        "pull-write-file": "^0.2.1"
+        "pull-file": "0.5.0",
+        "pull-stream": "3.6.8",
+        "pull-traverse": "1.0.3",
+        "pull-write-file": "0.2.4"
       },
       "dependencies": {
         "pull-file": {
@@ -3394,7 +2857,7 @@
           "integrity": "sha1-s8pAUwbggvnUUoKIkzutsrZWNls=",
           "dev": true,
           "requires": {
-            "pull-utf8-decoder": "^1.0.2"
+            "pull-utf8-decoder": "1.0.2"
           }
         }
       }
@@ -3405,8 +2868,8 @@
       "integrity": "sha1-7vkV3eZEvdvqjdLgEG1USqy81cI=",
       "dev": true,
       "requires": {
-        "pull-fs": "~1.1.6",
-        "pull-stream": "^3.3.0"
+        "pull-fs": "1.1.6",
+        "pull-stream": "3.6.8"
       }
     },
     "pull-goodbye": {
@@ -3415,7 +2878,7 @@
       "integrity": "sha1-jYNX21XiKnEN//DxaoyQtF7+QXE=",
       "dev": true,
       "requires": {
-        "pull-stream": "~3.5.0"
+        "pull-stream": "3.5.0"
       },
       "dependencies": {
         "pull-stream": {
@@ -3432,10 +2895,10 @@
       "integrity": "sha1-YACg/QGIhM39c3JU+Mxgqypjd5E=",
       "dev": true,
       "requires": {
-        "pull-cat": "^1.1.9",
-        "pull-pair": "~1.1.0",
-        "pull-pushable": "^2.0.0",
-        "pull-reader": "^1.2.3"
+        "pull-cat": "1.1.11",
+        "pull-pair": "1.1.0",
+        "pull-pushable": "2.2.0",
+        "pull-reader": "1.2.9"
       }
     },
     "pull-hash": {
@@ -3450,8 +2913,8 @@
       "integrity": "sha1-N6PW67+sKSzUNfXkgeUHTIwfrXU=",
       "dev": true,
       "requires": {
-        "pull-abortable": "~4.0.0",
-        "pull-stream": "^3.4.5"
+        "pull-abortable": "4.0.0",
+        "pull-stream": "3.6.8"
       },
       "dependencies": {
         "pull-abortable": {
@@ -3467,13 +2930,13 @@
       "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
       "integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
       "requires": {
-        "level-post": "^1.0.7",
-        "pull-cat": "^1.1.9",
-        "pull-live": "^1.0.1",
-        "pull-pushable": "^2.0.0",
-        "pull-stream": "^3.4.0",
-        "pull-window": "^2.1.4",
-        "stream-to-pull-stream": "^1.7.1"
+        "level-post": "1.0.7",
+        "pull-cat": "1.1.11",
+        "pull-live": "1.0.1",
+        "pull-pushable": "2.2.0",
+        "pull-stream": "3.6.8",
+        "pull-window": "2.1.4",
+        "stream-to-pull-stream": "1.7.2"
       }
     },
     "pull-live": {
@@ -3481,8 +2944,8 @@
       "resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
       "integrity": "sha1-pOzuAeMwFV6RJLu89HYfIbOPUfU=",
       "requires": {
-        "pull-cat": "^1.1.9",
-        "pull-stream": "^3.4.0"
+        "pull-cat": "1.1.11",
+        "pull-stream": "3.6.8"
       }
     },
     "pull-looper": {
@@ -3491,7 +2954,7 @@
       "integrity": "sha512-djlD60A6NGe5goLdP5pgbqzMEiWmk1bInuAzBp0QOH4vDrVwh05YDz6UP8+pOXveKEk8wHVP+rB2jBrK31QMPA==",
       "dev": true,
       "requires": {
-        "looper": "^4.0.0"
+        "looper": "4.0.0"
       },
       "dependencies": {
         "looper": {
@@ -3508,7 +2971,7 @@
       "integrity": "sha1-Pa3ZttFWxUVyG9qNAAPdjqoGKT4=",
       "dev": true,
       "requires": {
-        "pull-stream": "^3.4.5"
+        "pull-stream": "3.6.8"
       }
     },
     "pull-merge": {
@@ -3526,11 +2989,11 @@
       "resolved": "https://registry.npmjs.org/pull-next-query/-/pull-next-query-1.0.0.tgz",
       "integrity": "sha512-pZuaV0A6SH5IQmCNNBKB2WSpHfzgj/lNeprLvCMVRV2Wh4zidtBvjgJrThRLOYxdZilL4z01T3pri0zroqKJcg==",
       "requires": {
-        "lodash.get": "^4.4.2",
-        "lodash.merge": "^4.6.1",
-        "lodash.set": "^4.3.2",
-        "pull-next": "^1.0.1",
-        "pull-stream": "^3.6.8"
+        "lodash.get": "4.4.2",
+        "lodash.merge": "4.6.1",
+        "lodash.set": "4.3.2",
+        "pull-next": "1.0.1",
+        "pull-stream": "3.6.8"
       }
     },
     "pull-notify": {
@@ -3539,7 +3002,7 @@
       "integrity": "sha1-b4b/ldJwuJw+vyVbYDG3Ay3JnMo=",
       "dev": true,
       "requires": {
-        "pull-pushable": "^2.0.0"
+        "pull-pushable": "2.2.0"
       }
     },
     "pull-pair": {
@@ -3553,7 +3016,7 @@
       "resolved": "https://registry.npmjs.org/pull-paramap/-/pull-paramap-1.2.2.tgz",
       "integrity": "sha1-UaQZPOnI1yFdla2tReK824STsjo=",
       "requires": {
-        "looper": "^4.0.0"
+        "looper": "4.0.0"
       },
       "dependencies": {
         "looper": {
@@ -3569,9 +3032,9 @@
       "integrity": "sha1-e8SjQBZ9rYj2gqGWxjSFc1x6CJQ=",
       "dev": true,
       "requires": {
-        "pull-pushable": "^2.0.0",
-        "pull-stream": "^3.4.5",
-        "statistics": "^3.3.0"
+        "pull-pushable": "2.2.0",
+        "pull-stream": "3.6.8",
+        "statistics": "3.3.0"
       }
     },
     "pull-pushable": {
@@ -3585,7 +3048,7 @@
       "integrity": "sha1-F7IxrV81n2dYJmcBcrDlkMiWTo0=",
       "dev": true,
       "requires": {
-        "pull-stream": "^3.6.0"
+        "pull-stream": "3.6.8"
       }
     },
     "pull-reader": {
@@ -3622,7 +3085,7 @@
       "integrity": "sha1-jdYjFCY+Wc9Qlur7sSeitu8xBzU=",
       "dev": true,
       "requires": {
-        "looper": "~3.0.0"
+        "looper": "3.0.0"
       },
       "dependencies": {
         "looper": {
@@ -3650,7 +3113,7 @@
       "resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
       "integrity": "sha1-/DuG/uvRkgx64pdpHiP3BfiFUvA=",
       "requires": {
-        "looper": "^2.0.0"
+        "looper": "2.0.0"
       }
     },
     "pull-write": {
@@ -3658,9 +3121,9 @@
       "resolved": "https://registry.npmjs.org/pull-write/-/pull-write-1.1.4.tgz",
       "integrity": "sha1-3d6jFJO0j2douEooHQHrO1Mf4Lg=",
       "requires": {
-        "looper": "^4.0.0",
-        "pull-cat": "^1.1.11",
-        "pull-stream": "^3.4.5"
+        "looper": "4.0.0",
+        "pull-cat": "1.1.11",
+        "pull-stream": "3.6.8"
       },
       "dependencies": {
         "looper": {
@@ -3682,9 +3145,9 @@
       "integrity": "sha512-kJodbLQT+oKjcRIQO+vQNw6xWBuEo7Kxp51VMOvb6cvPvHYA+aNLzm+NmkB/5dZwbuTRYGMal9QPvH52tzM1ZA==",
       "dev": true,
       "requires": {
-        "relative-url": "^1.0.2",
-        "safe-buffer": "^5.1.1",
-        "ws": "^1.1.0"
+        "relative-url": "1.0.2",
+        "safe-buffer": "5.1.2",
+        "ws": "1.1.5"
       }
     },
     "pump": {
@@ -3692,8 +3155,8 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
       }
     },
     "push-stream": {
@@ -3708,7 +3171,7 @@
       "integrity": "sha512-gZe8pNlDFIi+0Ir2TeEFTpbrztLYVHvJgAjxOg8NFOcrisb9MKqIMSx+fmWMR6H/9PTZ2CwXubZlQWACKZ28Zw==",
       "dev": true,
       "requires": {
-        "pull-looper": "^1.0.0"
+        "pull-looper": "1.0.0"
       }
     },
     "randomatic": {
@@ -3717,9 +3180,9 @@
       "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
       "dev": true,
       "requires": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
+        "is-number": "4.0.0",
+        "kind-of": "6.0.2",
+        "math-random": "1.0.1"
       },
       "dependencies": {
         "is-number": {
@@ -3741,10 +3204,10 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
+        "deep-extend": "0.6.0",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -3759,13 +3222,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       },
       "dependencies": {
         "inherits": {
@@ -3781,10 +3244,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "readable-stream": "^2.0.2",
-        "set-immediate-shim": "^1.0.1"
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.6",
+        "set-immediate-shim": "1.0.1"
       }
     },
     "regenerator-runtime": {
@@ -3798,7 +3261,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "relative-url": {
@@ -3813,37 +3276,37 @@
       "integrity": "sha1-gCo4w6qYyeHj6gFe66IR0ny2Xh8=",
       "dev": true,
       "requires": {
-        "camelcase": "^2.0.0",
-        "ccount": "^1.0.0",
-        "chalk": "^1.0.0",
-        "chokidar": "^1.0.5",
-        "collapse-white-space": "^1.0.0",
-        "commander": "^2.0.0",
-        "concat-stream": "^1.0.0",
-        "debug": "^2.0.0",
-        "elegant-spinner": "^1.0.0",
+        "camelcase": "2.1.1",
+        "ccount": "1.0.3",
+        "chalk": "1.1.3",
+        "chokidar": "1.7.0",
+        "collapse-white-space": "1.0.4",
+        "commander": "2.15.1",
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "elegant-spinner": "1.0.1",
         "extend.js": "0.0.2",
-        "glob": "^6.0.1",
-        "globby": "^4.0.0",
-        "he": "^0.5.0",
-        "log-update": "^1.0.1",
-        "longest-streak": "^1.0.0",
-        "markdown-table": "^0.4.0",
-        "minimatch": "^3.0.0",
-        "npm-prefix": "^1.0.1",
-        "parse-entities": "^1.0.0",
-        "repeat-string": "^1.5.0",
-        "stringify-entities": "^1.0.0",
-        "to-vfile": "^1.0.0",
-        "trim": "^0.0.1",
-        "trim-trailing-lines": "^1.0.0",
-        "unified": "^2.0.0",
-        "user-home": "^2.0.0",
-        "vfile": "^1.1.0",
-        "vfile-find-down": "^1.0.0",
-        "vfile-find-up": "^1.0.0",
-        "vfile-reporter": "^1.5.0",
-        "ware": "^1.3.0"
+        "glob": "6.0.4",
+        "globby": "4.1.0",
+        "he": "0.5.0",
+        "log-update": "1.0.2",
+        "longest-streak": "1.0.0",
+        "markdown-table": "0.4.0",
+        "minimatch": "3.0.4",
+        "npm-prefix": "1.2.0",
+        "parse-entities": "1.1.2",
+        "repeat-string": "1.6.1",
+        "stringify-entities": "1.3.2",
+        "to-vfile": "1.0.0",
+        "trim": "0.0.1",
+        "trim-trailing-lines": "1.1.1",
+        "unified": "2.1.4",
+        "user-home": "2.0.0",
+        "vfile": "1.4.0",
+        "vfile-find-down": "1.0.0",
+        "vfile-find-up": "1.0.0",
+        "vfile-reporter": "1.5.0",
+        "ware": "1.3.0"
       },
       "dependencies": {
         "glob": {
@@ -3852,11 +3315,11 @@
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.1",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -3867,13 +3330,13 @@
       "integrity": "sha1-WSo0e909WIH08IDJi1sVL7FAepI=",
       "dev": true,
       "requires": {
-        "collapse-white-space": "^1.0.0",
-        "detab": "^1.0.0",
-        "normalize-uri": "^1.0.0",
-        "object-assign": "^4.0.1",
+        "collapse-white-space": "1.0.4",
+        "detab": "1.0.2",
+        "normalize-uri": "1.1.1",
+        "object-assign": "4.1.1",
         "trim": "0.0.1",
-        "trim-lines": "^1.0.0",
-        "unist-util-visit": "^1.0.0"
+        "trim-lines": "1.1.1",
+        "unist-util-visit": "1.3.1"
       }
     },
     "remove-trailing-separator": {
@@ -3899,7 +3362,7 @@
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "resolve": {
@@ -3908,7 +3371,7 @@
       "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.5"
       }
     },
     "restore-cursor": {
@@ -3917,8 +3380,8 @@
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
-        "exit-hook": "^1.0.0",
-        "onetime": "^1.0.0"
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
       }
     },
     "resumer": {
@@ -3927,7 +3390,7 @@
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
       "dev": true,
       "requires": {
-        "through": "~2.3.4"
+        "through": "2.3.8"
       }
     },
     "rimraf": {
@@ -3936,7 +3399,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       }
     },
     "safe-buffer": {
@@ -3949,9 +3412,9 @@
       "resolved": "https://registry.npmjs.org/scuttle-inject/-/scuttle-inject-1.0.0.tgz",
       "integrity": "sha512-TCOL3FT/7SVPydoXWeQHXFdxfPds4hqT5KyDc/hEs2P4L79u7bDikqZwb0fp0/hgV7HdS4Mcg/EgHku3GfvhvA==",
       "requires": {
-        "libnested": "^1.3.2",
-        "mutant": "^3.22.1",
-        "pull-defer": "^0.2.2"
+        "libnested": "1.3.2",
+        "mutant": "3.22.1",
+        "pull-defer": "0.2.2"
       }
     },
     "scuttle-testbot": {
@@ -3960,9 +3423,9 @@
       "integrity": "sha512-CdVTjPK+kN2kePz43XQCvsh2LE4TKKKZcBjyXVRPXZNR3AC10vhlKn+8GkFdLwjxoiRAPFGnrUjPTeHKUSvwjQ==",
       "dev": true,
       "requires": {
-        "rimraf": "^2.6.2",
-        "scuttlebot": "^11.1.0",
-        "ssb-keys": "^7.0.13"
+        "rimraf": "2.6.2",
+        "scuttlebot": "11.3.3",
+        "ssb-keys": "7.0.16"
       }
     },
     "scuttlebot": {
@@ -3972,62 +3435,62 @@
       "dev": true,
       "requires": {
         "atomic-file": "0.0.1",
-        "bash-color": "~0.0.3",
-        "broadcast-stream": "^0.2.1",
-        "cont": "~1.0.3",
-        "cross-spawn": "^5.1.0",
-        "deep-equal": "^1.0.1",
-        "explain-error": "^1.0.3",
+        "bash-color": "0.0.4",
+        "broadcast-stream": "0.2.2",
+        "cont": "1.0.3",
+        "cross-spawn": "5.1.0",
+        "deep-equal": "1.0.1",
+        "explain-error": "1.0.4",
         "has-network": "0.0.1",
-        "ip": "^0.3.3",
-        "mdmanifest": "^1.0.4",
-        "minimist": "^1.1.3",
-        "mkdirp": "~0.5.0",
-        "multiblob": "^1.13.0",
-        "multicb": "^1.0.0",
-        "multiserver": "^1.12.0",
-        "muxrpc": "^6.4.0",
-        "muxrpc-validation": "^2.0.0",
-        "muxrpcli": "^1.0.0",
-        "mv": "^2.1.1",
-        "non-private-ip": "^1.4.3",
-        "observ-debounce": "^1.1.1",
+        "ip": "0.3.3",
+        "mdmanifest": "1.0.8",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "multiblob": "1.13.0",
+        "multicb": "1.2.2",
+        "multiserver": "1.12.0",
+        "muxrpc": "6.4.0",
+        "muxrpc-validation": "2.0.1",
+        "muxrpcli": "1.1.0",
+        "mv": "2.1.1",
+        "non-private-ip": "1.4.4",
+        "observ-debounce": "1.1.1",
         "obv": "0.0.1",
         "on-change-network": "0.0.2",
-        "on-wakeup": "^1.0.0",
-        "osenv": "^0.1.5",
-        "pull-abortable": "~4.1.0",
-        "pull-cat": "~1.1.5",
-        "pull-file": "^1.0.0",
+        "on-wakeup": "1.0.1",
+        "osenv": "0.1.5",
+        "pull-abortable": "4.1.1",
+        "pull-cat": "1.1.11",
+        "pull-file": "1.1.0",
         "pull-flatmap": "0.0.1",
-        "pull-inactivity": "~2.1.1",
-        "pull-level": "^2.0.2",
-        "pull-many": "~1.0.6",
-        "pull-next": "^1.0.0",
+        "pull-inactivity": "2.1.2",
+        "pull-level": "2.0.4",
+        "pull-many": "1.0.8",
+        "pull-next": "1.0.1",
         "pull-notify": "0.1.1",
-        "pull-paramap": "~1.2.1",
-        "pull-ping": "^2.0.2",
-        "pull-pushable": "^2.2.0",
-        "pull-stream": "^3.6.2",
-        "pull-stream-to-stream": "~1.3.0",
-        "pull-stringify": "~1.2.2",
-        "rimraf": "^2.4.2",
-        "secret-stack": "^4.1.0",
-        "secure-scuttlebutt": "^18.0.7",
-        "ssb-blobs": "^1.1.4",
-        "ssb-client": "^4.5.7",
-        "ssb-config": "^2.0.0",
-        "ssb-ebt": "^5.1.4",
-        "ssb-friends": "^2.4.0",
-        "ssb-keys": "^7.0.13",
-        "ssb-links": "^3.0.2",
-        "ssb-msgs": "~5.2.0",
-        "ssb-query": "^2.1.0",
-        "ssb-ref": "^2.9.1",
-        "ssb-ws": "^2.1.1",
-        "statistics": "^3.0.0",
-        "stream-to-pull-stream": "^1.6.10",
-        "zerr": "^1.0.0"
+        "pull-paramap": "1.2.2",
+        "pull-ping": "2.0.2",
+        "pull-pushable": "2.2.0",
+        "pull-stream": "3.6.8",
+        "pull-stream-to-stream": "1.3.4",
+        "pull-stringify": "1.2.2",
+        "rimraf": "2.6.2",
+        "secret-stack": "4.1.0",
+        "secure-scuttlebutt": "18.0.7",
+        "ssb-blobs": "1.1.5",
+        "ssb-client": "4.5.7",
+        "ssb-config": "2.2.0",
+        "ssb-ebt": "5.2.0",
+        "ssb-friends": "2.4.0",
+        "ssb-keys": "7.0.16",
+        "ssb-links": "3.0.3",
+        "ssb-msgs": "5.2.0",
+        "ssb-query": "2.1.0",
+        "ssb-ref": "2.11.1",
+        "ssb-ws": "2.1.1",
+        "statistics": "3.3.0",
+        "stream-to-pull-stream": "1.7.2",
+        "zerr": "1.0.4"
       },
       "dependencies": {
         "atomic-file": {
@@ -4062,11 +3525,11 @@
       "integrity": "sha512-jDpA1kPJGg+jEUOZGvqksQFGPWIx0aA96HpjU+AqIBKIKzmvZeOq0Lfl/XqVC5jviWTVZZM2B8+NqYR38Blz8A==",
       "dev": true,
       "requires": {
-        "chloride": "^2.2.7",
-        "deep-equal": "~1.0.0",
-        "pull-box-stream": "^1.0.13",
-        "pull-handshake": "^1.1.1",
-        "pull-stream": "^3.4.5"
+        "chloride": "2.2.10",
+        "deep-equal": "1.0.1",
+        "pull-box-stream": "1.0.13",
+        "pull-handshake": "1.1.4",
+        "pull-stream": "3.6.8"
       }
     },
     "secret-stack": {
@@ -4076,15 +3539,15 @@
       "dev": true,
       "requires": {
         "hoox": "0.0.1",
-        "ip": "^1.1.5",
-        "map-merge": "^1.1.0",
-        "multiserver": "^1.11.0",
-        "muxrpc": "^6.4.0",
-        "non-private-ip": "^1.4.3",
-        "pull-inactivity": "~2.1.1",
-        "pull-rate": "^1.0.2",
-        "pull-stream": "^3.4.5",
-        "stream-to-pull-stream": "^1.6.1"
+        "ip": "1.1.5",
+        "map-merge": "1.1.0",
+        "multiserver": "1.12.0",
+        "muxrpc": "6.4.0",
+        "non-private-ip": "1.4.4",
+        "pull-inactivity": "2.1.2",
+        "pull-rate": "1.0.2",
+        "pull-stream": "3.6.8",
+        "stream-to-pull-stream": "1.7.2"
       }
     },
     "secure-scuttlebutt": {
@@ -4093,32 +3556,32 @@
       "integrity": "sha512-kowJ7xeXhaTm8Kz6cXOXll0Qvzq6lfqXDMTWyuVtYaPLmeEsyx8VKOS01f3OEpZhLWWx3SkqNrFAMvplvAdBxw==",
       "dev": true,
       "requires": {
-        "async-write": "^2.1.0",
-        "cont": "~1.0.0",
-        "deep-equal": "~0.2.1",
-        "explain-error": "~1.0.1",
+        "async-write": "2.1.0",
+        "cont": "1.0.3",
+        "deep-equal": "0.2.2",
+        "explain-error": "1.0.4",
         "flumecodec": "0.0.1",
-        "flumedb": "^0.4.2",
-        "flumelog-offset": "^3.3.1",
-        "flumeview-hashtable": "^1.0.3",
-        "flumeview-level": "^3.0.5",
-        "flumeview-reduce": "^1.3.9",
-        "level": "^3.0.1",
-        "level-sublevel": "^6.6.2",
-        "ltgt": "^2.2.0",
-        "monotonic-timestamp": "~0.0.8",
+        "flumedb": "0.4.8",
+        "flumelog-offset": "3.3.1",
+        "flumeview-hashtable": "1.0.3",
+        "flumeview-level": "3.0.5",
+        "flumeview-reduce": "1.3.13",
+        "level": "3.0.2",
+        "level-sublevel": "6.6.2",
+        "ltgt": "2.2.1",
+        "monotonic-timestamp": "0.0.9",
         "obv": "0.0.1",
         "pull-cont": "0.0.0",
-        "pull-level": "^2.0.3",
-        "pull-live": "^1.0.1",
-        "pull-notify": "^0.1.0",
-        "pull-paramap": "^1.1.6",
-        "pull-stream": "^3.4.0",
-        "ssb-keys": "^7.0.15",
-        "ssb-msgs": "^5.0.0",
-        "ssb-ref": "^2.0.0",
-        "ssb-validate": "^3.0.1",
-        "typewiselite": "^1.0.0"
+        "pull-level": "2.0.4",
+        "pull-live": "1.0.1",
+        "pull-notify": "0.1.1",
+        "pull-paramap": "1.2.2",
+        "pull-stream": "3.6.8",
+        "ssb-keys": "7.0.16",
+        "ssb-msgs": "5.2.0",
+        "ssb-ref": "2.11.1",
+        "ssb-validate": "3.0.9",
+        "typewiselite": "1.0.0"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -4127,7 +3590,7 @@
           "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
           "dev": true,
           "requires": {
-            "xtend": "~4.0.0"
+            "xtend": "4.0.1"
           }
         },
         "bindings": {
@@ -4148,7 +3611,7 @@
           "integrity": "sha512-ajbXqRPMXRlcdyt0TuWqknOJkp1JgQjGB7xOl2V+ebol7/U11E9h3/nCZAtN1M7djmAJEIhypCUc1tIWxdQAuQ==",
           "dev": true,
           "requires": {
-            "abstract-leveldown": "~4.0.0"
+            "abstract-leveldown": "4.0.3"
           }
         },
         "flumecodec": {
@@ -4157,7 +3620,7 @@
           "integrity": "sha1-rgSacUOGu4PjQmV6gpJLcDZKkNY=",
           "dev": true,
           "requires": {
-            "level-codec": "^6.2.0"
+            "level-codec": "6.2.0"
           }
         },
         "flumeview-level": {
@@ -4166,16 +3629,16 @@
           "integrity": "sha512-LKW+YdJGemOo7TnUwpFHq4cBBiYAIKtWk+G2CK7zrxbCIiAHemBRudohBOUKuSUZZ0CReR5fJ73peBHW02VerA==",
           "dev": true,
           "requires": {
-            "charwise": "^3.0.1",
-            "explain-error": "^1.0.4",
-            "level": "^3.0.1",
-            "ltgt": "^2.1.3",
-            "mkdirp": "^0.5.1",
+            "charwise": "3.0.1",
+            "explain-error": "1.0.4",
+            "level": "3.0.2",
+            "ltgt": "2.2.1",
+            "mkdirp": "0.5.1",
             "obv": "0.0.0",
-            "pull-level": "^2.0.3",
-            "pull-paramap": "^1.2.1",
-            "pull-stream": "^3.5.0",
-            "pull-write": "^1.1.1"
+            "pull-level": "2.0.4",
+            "pull-paramap": "1.2.2",
+            "pull-stream": "3.6.8",
+            "pull-write": "1.1.4"
           },
           "dependencies": {
             "obv": {
@@ -4192,9 +3655,9 @@
           "integrity": "sha512-2qYbbiptPsPWGUI+AgB1gTNXqIjPpALRqrQyNx1zWYNZxhhuzEj/IE4Unu9weEBnsUEocfYe56xOGlAceb8/Fg==",
           "dev": true,
           "requires": {
-            "level-packager": "^2.0.2",
-            "leveldown": "^3.0.0",
-            "opencollective-postinstall": "^2.0.0"
+            "level-packager": "2.1.1",
+            "leveldown": "3.0.2",
+            "opencollective-postinstall": "2.0.0"
           }
         },
         "level-codec": {
@@ -4209,7 +3672,7 @@
           "integrity": "sha512-Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==",
           "dev": true,
           "requires": {
-            "errno": "~0.1.1"
+            "errno": "0.1.7"
           }
         },
         "level-iterator-stream": {
@@ -4218,9 +3681,9 @@
           "integrity": "sha512-GAHN00KMxAxyuBX7jdGAMnoOeVQOggRsJ0QJOtasnTVHgYHfvfwogXeROXHLWb/IJZWcR5a4BvSlrDNi2/RkUA==",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.5",
-            "xtend": "^4.0.0"
+            "inherits": "2.0.1",
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
           }
         },
         "level-packager": {
@@ -4229,8 +3692,8 @@
           "integrity": "sha512-6l3G6dVkmdvHwOJrEA9d9hL6SSFrzwjQoLP8HsvohOgfY/8Z9LyTKNCM5Gc84wtsUWCuIHu6r+S6WrCtTWUJCw==",
           "dev": true,
           "requires": {
-            "encoding-down": "~4.0.0",
-            "levelup": "^2.0.0"
+            "encoding-down": "4.0.1",
+            "levelup": "2.0.2"
           }
         },
         "leveldown": {
@@ -4239,11 +3702,11 @@
           "integrity": "sha512-+ANRScj1npQQzv6e4DYAKRjVQZZ+ahMoubKrNP68nIq+l9bYgb+WiXF+14oTcQTg2f7qE9WHGW7rBG9nGSsA+A==",
           "dev": true,
           "requires": {
-            "abstract-leveldown": "~4.0.0",
-            "bindings": "~1.3.0",
-            "fast-future": "~1.0.2",
-            "nan": "~2.10.0",
-            "prebuild-install": "^4.0.0"
+            "abstract-leveldown": "4.0.3",
+            "bindings": "1.3.0",
+            "fast-future": "1.0.2",
+            "nan": "2.10.0",
+            "prebuild-install": "4.0.0"
           }
         },
         "levelup": {
@@ -4252,10 +3715,10 @@
           "integrity": "sha512-us+nTLUyd/eLnclYYddOCdAVw1hnymGx/9p4Jr5ThohStsjLqMVmbYiz6/SYFZEPXNF+AKQSvh6fA2e2KZpC8w==",
           "dev": true,
           "requires": {
-            "deferred-leveldown": "~3.0.0",
-            "level-errors": "~1.1.0",
-            "level-iterator-stream": "~2.0.0",
-            "xtend": "~4.0.0"
+            "deferred-leveldown": "3.0.0",
+            "level-errors": "1.1.2",
+            "level-iterator-stream": "2.0.1",
+            "xtend": "4.0.1"
           }
         },
         "minimist": {
@@ -4282,21 +3745,21 @@
           "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
           "dev": true,
           "requires": {
-            "detect-libc": "^1.0.3",
-            "expand-template": "^1.0.2",
+            "detect-libc": "1.0.3",
+            "expand-template": "1.1.1",
             "github-from-package": "0.0.0",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "node-abi": "^2.2.0",
-            "noop-logger": "^0.1.1",
-            "npmlog": "^4.0.1",
-            "os-homedir": "^1.0.1",
-            "pump": "^2.0.1",
-            "rc": "^1.1.6",
-            "simple-get": "^2.7.0",
-            "tar-fs": "^1.13.0",
-            "tunnel-agent": "^0.6.0",
-            "which-pm-runs": "^1.0.0"
+            "minimist": "1.2.0",
+            "mkdirp": "0.5.1",
+            "node-abi": "2.4.1",
+            "noop-logger": "0.1.1",
+            "npmlog": "4.1.2",
+            "os-homedir": "1.0.2",
+            "pump": "2.0.1",
+            "rc": "1.2.8",
+            "simple-get": "2.8.1",
+            "tar-fs": "1.16.2",
+            "tunnel-agent": "0.6.0",
+            "which-pm-runs": "1.0.0"
           }
         }
       }
@@ -4328,7 +3791,7 @@
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz",
       "integrity": "sha1-J9Fx78yCoRi5ljn/WBZgJCtQbnw=",
       "requires": {
-        "inherits": "^2.0.1"
+        "inherits": "2.0.1"
       }
     },
     "shebang-command": {
@@ -4337,7 +3800,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -4367,9 +3830,9 @@
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
       "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
       "requires": {
-        "decompress-response": "^3.3.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
+        "decompress-response": "3.3.0",
+        "once": "1.4.0",
+        "simple-concat": "1.0.0"
       }
     },
     "slash": {
@@ -4389,8 +3852,8 @@
       "integrity": "sha1-Yo1+TQSRJDVEWsC25Fk3bLPm1pE=",
       "dev": true,
       "requires": {
-        "ip": "^1.1.2",
-        "smart-buffer": "^1.0.4"
+        "ip": "1.1.5",
+        "smart-buffer": "1.1.15"
       }
     },
     "sodium-browserify": {
@@ -4398,10 +3861,10 @@
       "resolved": "https://registry.npmjs.org/sodium-browserify/-/sodium-browserify-1.2.4.tgz",
       "integrity": "sha512-IYcxKje/uf/c3a7VhZYJLlUxWMcktfbD4AjqHjUD1/VWKjj0Oq5wNbX8wjJOWVO9UhUMqJQiOn2xFbzKWBmy5w==",
       "requires": {
-        "libsodium-wrappers": "^0.7.3",
+        "libsodium-wrappers": "0.7.3",
         "sha.js": "2.4.5",
-        "sodium-browserify-tweetnacl": "^0.2.3",
-        "tweetnacl": "^0.14.1"
+        "sodium-browserify-tweetnacl": "0.2.3",
+        "tweetnacl": "0.14.5"
       }
     },
     "sodium-browserify-tweetnacl": {
@@ -4409,11 +3872,11 @@
       "resolved": "https://registry.npmjs.org/sodium-browserify-tweetnacl/-/sodium-browserify-tweetnacl-0.2.3.tgz",
       "integrity": "sha1-tVN//LufdOvEQ7i2ohGykej8vI4=",
       "requires": {
-        "chloride-test": "^1.1.0",
-        "ed2curve": "^0.1.4",
-        "sha.js": "^2.4.8",
-        "tweetnacl": "^0.14.1",
-        "tweetnacl-auth": "^0.3.0"
+        "chloride-test": "1.2.2",
+        "ed2curve": "0.1.4",
+        "sha.js": "2.4.11",
+        "tweetnacl": "0.14.5",
+        "tweetnacl-auth": "0.3.1"
       },
       "dependencies": {
         "sha.js": {
@@ -4421,8 +3884,8 @@
           "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
           "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
           "requires": {
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.0.1"
+            "inherits": "2.0.1",
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -4438,9 +3901,9 @@
       "integrity": "sha512-vfovcNlU8C93SbeNoGSAdW5zVOTlrh1sTy+TzdC2FhDTE/IUK6j4ML5gdr/qziLz4XRT4EQWJvbFzql6CAAH/A==",
       "optional": true,
       "requires": {
-        "ini": "^1.3.5",
-        "nan": "^2.4.0",
-        "node-gyp-build": "^3.0.0"
+        "ini": "1.3.5",
+        "nan": "2.6.2",
+        "node-gyp-build": "3.3.0"
       }
     },
     "source-map": {
@@ -4453,7 +3916,7 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "requires": {
-        "source-map": "^0.5.6"
+        "source-map": "0.5.7"
       }
     },
     "split-buffer": {
@@ -4473,13 +3936,13 @@
       "resolved": "https://registry.npmjs.org/ssb-backlinks/-/ssb-backlinks-0.7.3.tgz",
       "integrity": "sha512-84s5phSVyZsYV0FTmBJvICPgOMuu8ouzukG8Gz2XtuOui95GBP/G7UIBURgYVS82XA6g9xPA/jf38fsMxid38Q==",
       "requires": {
-        "base64-url": "^2.2.0",
-        "deep-equal": "^1.0.1",
-        "flumeview-query": "^6.2.0",
-        "pull-stream": "^3.6.7",
-        "ssb-keys": "^7.0.14",
-        "ssb-ref": "^2.9.0",
-        "xtend": "^4.0.1"
+        "base64-url": "2.2.0",
+        "deep-equal": "1.0.1",
+        "flumeview-query": "6.2.0",
+        "pull-stream": "3.6.8",
+        "ssb-keys": "7.0.16",
+        "ssb-ref": "2.11.1",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -4487,7 +3950,7 @@
           "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
           "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
           "requires": {
-            "xtend": "~4.0.0"
+            "xtend": "4.0.1"
           }
         },
         "base64-url": {
@@ -4505,7 +3968,7 @@
           "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-3.0.0.tgz",
           "integrity": "sha512-ajbXqRPMXRlcdyt0TuWqknOJkp1JgQjGB7xOl2V+ebol7/U11E9h3/nCZAtN1M7djmAJEIhypCUc1tIWxdQAuQ==",
           "requires": {
-            "abstract-leveldown": "~4.0.0"
+            "abstract-leveldown": "4.0.3"
           }
         },
         "flumeview-level": {
@@ -4513,16 +3976,16 @@
           "resolved": "https://registry.npmjs.org/flumeview-level/-/flumeview-level-3.0.5.tgz",
           "integrity": "sha512-LKW+YdJGemOo7TnUwpFHq4cBBiYAIKtWk+G2CK7zrxbCIiAHemBRudohBOUKuSUZZ0CReR5fJ73peBHW02VerA==",
           "requires": {
-            "charwise": "^3.0.1",
-            "explain-error": "^1.0.4",
-            "level": "^3.0.1",
-            "ltgt": "^2.1.3",
-            "mkdirp": "^0.5.1",
+            "charwise": "3.0.1",
+            "explain-error": "1.0.4",
+            "level": "3.0.2",
+            "ltgt": "2.2.1",
+            "mkdirp": "0.5.1",
             "obv": "0.0.0",
-            "pull-level": "^2.0.3",
-            "pull-paramap": "^1.2.1",
-            "pull-stream": "^3.5.0",
-            "pull-write": "^1.1.1"
+            "pull-level": "2.0.4",
+            "pull-paramap": "1.2.2",
+            "pull-stream": "3.6.8",
+            "pull-write": "1.1.4"
           }
         },
         "flumeview-query": {
@@ -4530,13 +3993,13 @@
           "resolved": "https://registry.npmjs.org/flumeview-query/-/flumeview-query-6.2.0.tgz",
           "integrity": "sha512-tq7rD63gixBDOPegw10khz/d5Bnq9qW9IbURHbWuJkG5CUBm3JP4QQSIF/Phl99jz66MRuXoXjRrXXQLN89iNQ==",
           "requires": {
-            "deep-equal": "^1.0.1",
-            "flumeview-level": "^3.0.0",
-            "map-filter-reduce": "^3.0.7",
+            "deep-equal": "1.0.1",
+            "flumeview-level": "3.0.5",
+            "map-filter-reduce": "3.1.0",
             "pull-flatmap": "0.0.1",
-            "pull-paramap": "^1.1.3",
+            "pull-paramap": "1.2.2",
             "pull-sink-through": "0.0.0",
-            "pull-stream": "^3.4.0"
+            "pull-stream": "3.6.8"
           }
         },
         "level": {
@@ -4544,9 +4007,9 @@
           "resolved": "https://registry.npmjs.org/level/-/level-3.0.2.tgz",
           "integrity": "sha512-2qYbbiptPsPWGUI+AgB1gTNXqIjPpALRqrQyNx1zWYNZxhhuzEj/IE4Unu9weEBnsUEocfYe56xOGlAceb8/Fg==",
           "requires": {
-            "level-packager": "^2.0.2",
-            "leveldown": "^3.0.0",
-            "opencollective-postinstall": "^2.0.0"
+            "level-packager": "2.1.1",
+            "leveldown": "3.0.2",
+            "opencollective-postinstall": "2.0.0"
           }
         },
         "level-errors": {
@@ -4554,7 +4017,7 @@
           "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.1.2.tgz",
           "integrity": "sha512-Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==",
           "requires": {
-            "errno": "~0.1.1"
+            "errno": "0.1.7"
           }
         },
         "level-iterator-stream": {
@@ -4562,9 +4025,9 @@
           "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
           "integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
           "requires": {
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.5",
-            "xtend": "^4.0.0"
+            "inherits": "2.0.1",
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
           }
         },
         "level-packager": {
@@ -4572,8 +4035,8 @@
           "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-2.1.1.tgz",
           "integrity": "sha512-6l3G6dVkmdvHwOJrEA9d9hL6SSFrzwjQoLP8HsvohOgfY/8Z9LyTKNCM5Gc84wtsUWCuIHu6r+S6WrCtTWUJCw==",
           "requires": {
-            "encoding-down": "~4.0.0",
-            "levelup": "^2.0.0"
+            "encoding-down": "4.0.1",
+            "levelup": "2.0.2"
           }
         },
         "leveldown": {
@@ -4581,11 +4044,11 @@
           "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-3.0.2.tgz",
           "integrity": "sha512-+ANRScj1npQQzv6e4DYAKRjVQZZ+ahMoubKrNP68nIq+l9bYgb+WiXF+14oTcQTg2f7qE9WHGW7rBG9nGSsA+A==",
           "requires": {
-            "abstract-leveldown": "~4.0.0",
-            "bindings": "~1.3.0",
-            "fast-future": "~1.0.2",
-            "nan": "~2.10.0",
-            "prebuild-install": "^4.0.0"
+            "abstract-leveldown": "4.0.3",
+            "bindings": "1.3.0",
+            "fast-future": "1.0.2",
+            "nan": "2.10.0",
+            "prebuild-install": "4.0.0"
           }
         },
         "levelup": {
@@ -4593,10 +4056,10 @@
           "resolved": "https://registry.npmjs.org/levelup/-/levelup-2.0.2.tgz",
           "integrity": "sha512-us+nTLUyd/eLnclYYddOCdAVw1hnymGx/9p4Jr5ThohStsjLqMVmbYiz6/SYFZEPXNF+AKQSvh6fA2e2KZpC8w==",
           "requires": {
-            "deferred-leveldown": "~3.0.0",
-            "level-errors": "~1.1.0",
-            "level-iterator-stream": "~2.0.0",
-            "xtend": "~4.0.0"
+            "deferred-leveldown": "3.0.0",
+            "level-errors": "1.1.2",
+            "level-iterator-stream": "2.0.3",
+            "xtend": "4.0.1"
           }
         },
         "minimist": {
@@ -4614,21 +4077,21 @@
           "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
           "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
           "requires": {
-            "detect-libc": "^1.0.3",
-            "expand-template": "^1.0.2",
+            "detect-libc": "1.0.3",
+            "expand-template": "1.1.1",
             "github-from-package": "0.0.0",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "node-abi": "^2.2.0",
-            "noop-logger": "^0.1.1",
-            "npmlog": "^4.0.1",
-            "os-homedir": "^1.0.1",
-            "pump": "^2.0.1",
-            "rc": "^1.1.6",
-            "simple-get": "^2.7.0",
-            "tar-fs": "^1.13.0",
-            "tunnel-agent": "^0.6.0",
-            "which-pm-runs": "^1.0.0"
+            "minimist": "1.2.0",
+            "mkdirp": "0.5.1",
+            "node-abi": "2.4.1",
+            "noop-logger": "0.1.1",
+            "npmlog": "4.1.2",
+            "os-homedir": "1.0.2",
+            "pump": "2.0.1",
+            "rc": "1.2.8",
+            "simple-get": "2.8.1",
+            "tar-fs": "1.16.2",
+            "tunnel-agent": "0.6.0",
+            "which-pm-runs": "1.0.0"
           }
         }
       }
@@ -4639,13 +4102,13 @@
       "integrity": "sha512-DeeInkFU8oN1mYlPVrqrm9tupf6wze4HuowK7N2vv/O+UeSLuYPU1p4HrxSqdAPvUabr0OtvbFA6z1T4nw+9fw==",
       "dev": true,
       "requires": {
-        "cont": "^1.0.3",
-        "level": "^3.0.0",
-        "multiblob": "^1.12.0",
-        "pull-level": "^2.0.4",
-        "pull-notify": "^0.1.0",
-        "pull-stream": "^3.3.0",
-        "ssb-ref": "^2.3.0"
+        "cont": "1.0.3",
+        "level": "3.0.2",
+        "multiblob": "1.13.0",
+        "pull-level": "2.0.4",
+        "pull-notify": "0.1.1",
+        "pull-stream": "3.6.8",
+        "ssb-ref": "2.11.1"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -4654,7 +4117,7 @@
           "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
           "dev": true,
           "requires": {
-            "xtend": "~4.0.0"
+            "xtend": "4.0.1"
           }
         },
         "bindings": {
@@ -4669,7 +4132,7 @@
           "integrity": "sha512-ajbXqRPMXRlcdyt0TuWqknOJkp1JgQjGB7xOl2V+ebol7/U11E9h3/nCZAtN1M7djmAJEIhypCUc1tIWxdQAuQ==",
           "dev": true,
           "requires": {
-            "abstract-leveldown": "~4.0.0"
+            "abstract-leveldown": "4.0.3"
           }
         },
         "level": {
@@ -4678,9 +4141,9 @@
           "integrity": "sha512-2qYbbiptPsPWGUI+AgB1gTNXqIjPpALRqrQyNx1zWYNZxhhuzEj/IE4Unu9weEBnsUEocfYe56xOGlAceb8/Fg==",
           "dev": true,
           "requires": {
-            "level-packager": "^2.0.2",
-            "leveldown": "^3.0.0",
-            "opencollective-postinstall": "^2.0.0"
+            "level-packager": "2.1.1",
+            "leveldown": "3.0.2",
+            "opencollective-postinstall": "2.0.0"
           }
         },
         "level-errors": {
@@ -4689,7 +4152,7 @@
           "integrity": "sha512-Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==",
           "dev": true,
           "requires": {
-            "errno": "~0.1.1"
+            "errno": "0.1.7"
           }
         },
         "level-iterator-stream": {
@@ -4698,9 +4161,9 @@
           "integrity": "sha512-GAHN00KMxAxyuBX7jdGAMnoOeVQOggRsJ0QJOtasnTVHgYHfvfwogXeROXHLWb/IJZWcR5a4BvSlrDNi2/RkUA==",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.5",
-            "xtend": "^4.0.0"
+            "inherits": "2.0.1",
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
           }
         },
         "level-packager": {
@@ -4709,8 +4172,8 @@
           "integrity": "sha512-6l3G6dVkmdvHwOJrEA9d9hL6SSFrzwjQoLP8HsvohOgfY/8Z9LyTKNCM5Gc84wtsUWCuIHu6r+S6WrCtTWUJCw==",
           "dev": true,
           "requires": {
-            "encoding-down": "~4.0.0",
-            "levelup": "^2.0.0"
+            "encoding-down": "4.0.1",
+            "levelup": "2.0.2"
           }
         },
         "leveldown": {
@@ -4719,11 +4182,11 @@
           "integrity": "sha512-+ANRScj1npQQzv6e4DYAKRjVQZZ+ahMoubKrNP68nIq+l9bYgb+WiXF+14oTcQTg2f7qE9WHGW7rBG9nGSsA+A==",
           "dev": true,
           "requires": {
-            "abstract-leveldown": "~4.0.0",
-            "bindings": "~1.3.0",
-            "fast-future": "~1.0.2",
-            "nan": "~2.10.0",
-            "prebuild-install": "^4.0.0"
+            "abstract-leveldown": "4.0.3",
+            "bindings": "1.3.0",
+            "fast-future": "1.0.2",
+            "nan": "2.10.0",
+            "prebuild-install": "4.0.0"
           }
         },
         "levelup": {
@@ -4732,10 +4195,10 @@
           "integrity": "sha512-us+nTLUyd/eLnclYYddOCdAVw1hnymGx/9p4Jr5ThohStsjLqMVmbYiz6/SYFZEPXNF+AKQSvh6fA2e2KZpC8w==",
           "dev": true,
           "requires": {
-            "deferred-leveldown": "~3.0.0",
-            "level-errors": "~1.1.0",
-            "level-iterator-stream": "~2.0.0",
-            "xtend": "~4.0.0"
+            "deferred-leveldown": "3.0.0",
+            "level-errors": "1.1.2",
+            "level-iterator-stream": "2.0.1",
+            "xtend": "4.0.1"
           }
         },
         "minimist": {
@@ -4756,21 +4219,21 @@
           "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
           "dev": true,
           "requires": {
-            "detect-libc": "^1.0.3",
-            "expand-template": "^1.0.2",
+            "detect-libc": "1.0.3",
+            "expand-template": "1.1.1",
             "github-from-package": "0.0.0",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "node-abi": "^2.2.0",
-            "noop-logger": "^0.1.1",
-            "npmlog": "^4.0.1",
-            "os-homedir": "^1.0.1",
-            "pump": "^2.0.1",
-            "rc": "^1.1.6",
-            "simple-get": "^2.7.0",
-            "tar-fs": "^1.13.0",
-            "tunnel-agent": "^0.6.0",
-            "which-pm-runs": "^1.0.0"
+            "minimist": "1.2.0",
+            "mkdirp": "0.5.1",
+            "node-abi": "2.4.1",
+            "noop-logger": "0.1.1",
+            "npmlog": "4.1.2",
+            "os-homedir": "1.0.2",
+            "pump": "2.0.1",
+            "rc": "1.2.8",
+            "simple-get": "2.8.1",
+            "tar-fs": "1.16.2",
+            "tunnel-agent": "0.6.0",
+            "which-pm-runs": "1.0.0"
           }
         }
       }
@@ -4781,14 +4244,14 @@
       "integrity": "sha512-mEOyMlX6sGEUStU02vdSPD4j9ZRQQe3WCQwZCtgOkkrJpp7ARHxC0dx8ahumyq/vUIYWqQSAHHMD0+R63GmpGg==",
       "dev": true,
       "requires": {
-        "explain-error": "^1.0.1",
-        "multicb": "^1.2.1",
-        "multiserver": "^1.7.0",
-        "muxrpc": "^6.4.0",
-        "pull-hash": "^1.0.0",
-        "pull-stream": "^3.6.0",
-        "ssb-config": "^2.2.0",
-        "ssb-keys": "^7.0.13"
+        "explain-error": "1.0.4",
+        "multicb": "1.2.2",
+        "multiserver": "1.12.0",
+        "muxrpc": "6.4.0",
+        "pull-hash": "1.0.0",
+        "pull-stream": "3.6.8",
+        "ssb-config": "2.2.0",
+        "ssb-keys": "7.0.16"
       }
     },
     "ssb-config": {
@@ -4797,10 +4260,10 @@
       "integrity": "sha1-QcrQOKhXWvQGLT/VfTsWe+hbA7w=",
       "dev": true,
       "requires": {
-        "deep-extend": "^0.4.0",
-        "non-private-ip": "^1.2.1",
-        "os-homedir": "^1.0.1",
-        "rc": "^1.1.6"
+        "deep-extend": "0.4.2",
+        "non-private-ip": "1.4.4",
+        "os-homedir": "1.0.2",
+        "rc": "1.2.8"
       },
       "dependencies": {
         "deep-extend": {
@@ -4817,12 +4280,12 @@
       "integrity": "sha512-u7n5O2YRyF6SvX4RMxf7I1Mm6r95pmSKshx1CbmnOpa05PFzzFvi3vjiQnse1TEpWYcVpYn2zwugOVflZxZlhw==",
       "dev": true,
       "requires": {
-        "base64-url": "^1.3.3",
-        "epidemic-broadcast-trees": "^6.3.1",
-        "lossy-store": "^1.2.3",
-        "pull-stream": "^3.5.0",
-        "push-stream-to-pull-stream": "^1.0.0",
-        "ssb-ref": "^2.9.1"
+        "base64-url": "1.3.3",
+        "epidemic-broadcast-trees": "6.3.3",
+        "lossy-store": "1.2.3",
+        "pull-stream": "3.6.8",
+        "push-stream-to-pull-stream": "1.0.1",
+        "ssb-ref": "2.11.1"
       }
     },
     "ssb-friends": {
@@ -4831,13 +4294,13 @@
       "integrity": "sha1-DUDNlqEvIznJBkqK0dWnE+kcV64=",
       "dev": true,
       "requires": {
-        "flumeview-reduce": "^1.3.0",
-        "graphreduce": "^3.0.3",
+        "flumeview-reduce": "1.3.13",
+        "graphreduce": "3.0.4",
         "obv": "0.0.1",
-        "pull-cont": "^0.1.1",
+        "pull-cont": "0.1.1",
         "pull-flatmap": "0.0.1",
-        "pull-stream": "^3.6.0",
-        "ssb-ref": "^2.7.1"
+        "pull-stream": "3.6.8",
+        "ssb-ref": "2.11.1"
       },
       "dependencies": {
         "obv": {
@@ -4855,15 +4318,16 @@
       }
     },
     "ssb-invite-schema": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/ssb-invite-schema/-/ssb-invite-schema-0.0.8.tgz",
-      "integrity": "sha512-5Gp5gfURECWk+11D56vfvRH/jFm+tM6bUVsOf3G7qpJK6vW+IOojW7LY3tPCodvWHcu69zB1wcd9fye9BnrxeQ==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/ssb-invite-schema/-/ssb-invite-schema-0.0.10.tgz",
+      "integrity": "sha512-ofofSlTmC9CPdK7Vc4DkTc5hD3OCYZcb2XgiPUGf+8YZ0NhJJ+qKwTIAf29DAhTzXaZfQ2d4/Tjcpp5P38USFg==",
       "requires": {
-        "depject": "^4.1.1",
-        "depnest": "^1.3.0",
-        "is-my-json-valid": "^2.17.2",
-        "ssb-msg-content": "^1.0.1",
-        "ssb-ref": "^2.11.1"
+        "depject": "4.1.1",
+        "depnest": "1.3.0",
+        "is-my-json-valid": "2.17.2",
+        "ssb-msg-content": "1.0.1",
+        "ssb-ref": "2.11.1",
+        "ssb-schema-definitions": "1.0.8"
       }
     },
     "ssb-keys": {
@@ -4871,9 +4335,9 @@
       "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.0.16.tgz",
       "integrity": "sha512-EhLkRzgF7YaRc47L8YZb+TcxEXZy9DPWCF+vCt5nSNm8Oj+Pz8pBVSOlrLKZVbcAKFjIJhqY32oTjknu3E1KVQ==",
       "requires": {
-        "chloride": "^2.2.8",
-        "mkdirp": "~0.5.0",
-        "private-box": "^0.2.1"
+        "chloride": "2.2.10",
+        "mkdirp": "0.5.1",
+        "private-box": "0.2.1"
       }
     },
     "ssb-links": {
@@ -4882,10 +4346,10 @@
       "integrity": "sha512-x09ShIMjwvdZI7aDZm8kc1v5YCGZa9ulCOoxrf/RYJ98s5gbTfO9CBCzeMBAeQ5kRwSuKjiOxJHdeEBkj4Y6hw==",
       "dev": true,
       "requires": {
-        "flumeview-query": "^6.0.0",
-        "map-filter-reduce": "^2.0.0",
-        "pull-stream": "^3.1.0",
-        "ssb-msgs": "^5.2.0"
+        "flumeview-query": "6.2.0",
+        "map-filter-reduce": "2.2.1",
+        "pull-stream": "3.6.8",
+        "ssb-msgs": "5.2.0"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -4894,7 +4358,7 @@
           "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
           "dev": true,
           "requires": {
-            "xtend": "~4.0.0"
+            "xtend": "4.0.1"
           }
         },
         "bindings": {
@@ -4909,7 +4373,7 @@
           "integrity": "sha512-ajbXqRPMXRlcdyt0TuWqknOJkp1JgQjGB7xOl2V+ebol7/U11E9h3/nCZAtN1M7djmAJEIhypCUc1tIWxdQAuQ==",
           "dev": true,
           "requires": {
-            "abstract-leveldown": "~4.0.0"
+            "abstract-leveldown": "4.0.3"
           }
         },
         "flumeview-level": {
@@ -4918,16 +4382,16 @@
           "integrity": "sha512-LKW+YdJGemOo7TnUwpFHq4cBBiYAIKtWk+G2CK7zrxbCIiAHemBRudohBOUKuSUZZ0CReR5fJ73peBHW02VerA==",
           "dev": true,
           "requires": {
-            "charwise": "^3.0.1",
-            "explain-error": "^1.0.4",
-            "level": "^3.0.1",
-            "ltgt": "^2.1.3",
-            "mkdirp": "^0.5.1",
+            "charwise": "3.0.1",
+            "explain-error": "1.0.4",
+            "level": "3.0.2",
+            "ltgt": "2.2.1",
+            "mkdirp": "0.5.1",
             "obv": "0.0.0",
-            "pull-level": "^2.0.3",
-            "pull-paramap": "^1.2.1",
-            "pull-stream": "^3.5.0",
-            "pull-write": "^1.1.1"
+            "pull-level": "2.0.4",
+            "pull-paramap": "1.2.2",
+            "pull-stream": "3.6.8",
+            "pull-write": "1.1.4"
           }
         },
         "flumeview-query": {
@@ -4936,13 +4400,13 @@
           "integrity": "sha512-tq7rD63gixBDOPegw10khz/d5Bnq9qW9IbURHbWuJkG5CUBm3JP4QQSIF/Phl99jz66MRuXoXjRrXXQLN89iNQ==",
           "dev": true,
           "requires": {
-            "deep-equal": "^1.0.1",
-            "flumeview-level": "^3.0.0",
-            "map-filter-reduce": "^3.0.7",
+            "deep-equal": "1.0.1",
+            "flumeview-level": "3.0.5",
+            "map-filter-reduce": "3.1.0",
             "pull-flatmap": "0.0.1",
-            "pull-paramap": "^1.1.3",
+            "pull-paramap": "1.2.2",
             "pull-sink-through": "0.0.0",
-            "pull-stream": "^3.4.0"
+            "pull-stream": "3.6.8"
           },
           "dependencies": {
             "map-filter-reduce": {
@@ -4951,10 +4415,10 @@
               "integrity": "sha512-os2GlG1lEWRSAvAb9iqfapQ0I1GRXSA+alSjQl0DB7XxNyDx2/VOVAEVhK7EMsqwDDCWNTBSstoo1roc7U5H0w==",
               "dev": true,
               "requires": {
-                "binary-search": "^1.2.0",
+                "binary-search": "1.3.3",
                 "pull-sink-through": "0.0.0",
-                "pull-stream": "^3.4.3",
-                "typewiselite": "^1.0.0"
+                "pull-stream": "3.6.8",
+                "typewiselite": "1.0.0"
               }
             }
           }
@@ -4965,9 +4429,9 @@
           "integrity": "sha512-2qYbbiptPsPWGUI+AgB1gTNXqIjPpALRqrQyNx1zWYNZxhhuzEj/IE4Unu9weEBnsUEocfYe56xOGlAceb8/Fg==",
           "dev": true,
           "requires": {
-            "level-packager": "^2.0.2",
-            "leveldown": "^3.0.0",
-            "opencollective-postinstall": "^2.0.0"
+            "level-packager": "2.1.1",
+            "leveldown": "3.0.2",
+            "opencollective-postinstall": "2.0.0"
           }
         },
         "level-errors": {
@@ -4976,7 +4440,7 @@
           "integrity": "sha512-Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==",
           "dev": true,
           "requires": {
-            "errno": "~0.1.1"
+            "errno": "0.1.7"
           }
         },
         "level-iterator-stream": {
@@ -4985,9 +4449,9 @@
           "integrity": "sha512-GAHN00KMxAxyuBX7jdGAMnoOeVQOggRsJ0QJOtasnTVHgYHfvfwogXeROXHLWb/IJZWcR5a4BvSlrDNi2/RkUA==",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.5",
-            "xtend": "^4.0.0"
+            "inherits": "2.0.1",
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
           }
         },
         "level-packager": {
@@ -4996,8 +4460,8 @@
           "integrity": "sha512-6l3G6dVkmdvHwOJrEA9d9hL6SSFrzwjQoLP8HsvohOgfY/8Z9LyTKNCM5Gc84wtsUWCuIHu6r+S6WrCtTWUJCw==",
           "dev": true,
           "requires": {
-            "encoding-down": "~4.0.0",
-            "levelup": "^2.0.0"
+            "encoding-down": "4.0.1",
+            "levelup": "2.0.2"
           }
         },
         "leveldown": {
@@ -5006,11 +4470,11 @@
           "integrity": "sha512-+ANRScj1npQQzv6e4DYAKRjVQZZ+ahMoubKrNP68nIq+l9bYgb+WiXF+14oTcQTg2f7qE9WHGW7rBG9nGSsA+A==",
           "dev": true,
           "requires": {
-            "abstract-leveldown": "~4.0.0",
-            "bindings": "~1.3.0",
-            "fast-future": "~1.0.2",
-            "nan": "~2.10.0",
-            "prebuild-install": "^4.0.0"
+            "abstract-leveldown": "4.0.3",
+            "bindings": "1.3.0",
+            "fast-future": "1.0.2",
+            "nan": "2.10.0",
+            "prebuild-install": "4.0.0"
           }
         },
         "levelup": {
@@ -5019,10 +4483,10 @@
           "integrity": "sha512-us+nTLUyd/eLnclYYddOCdAVw1hnymGx/9p4Jr5ThohStsjLqMVmbYiz6/SYFZEPXNF+AKQSvh6fA2e2KZpC8w==",
           "dev": true,
           "requires": {
-            "deferred-leveldown": "~3.0.0",
-            "level-errors": "~1.1.0",
-            "level-iterator-stream": "~2.0.0",
-            "xtend": "~4.0.0"
+            "deferred-leveldown": "3.0.0",
+            "level-errors": "1.1.2",
+            "level-iterator-stream": "2.0.1",
+            "xtend": "4.0.1"
           }
         },
         "map-filter-reduce": {
@@ -5031,10 +4495,10 @@
           "integrity": "sha1-YysSfDrl1q2eIc/dlpG2O4lE/NI=",
           "dev": true,
           "requires": {
-            "binary-search": "^1.2.0",
+            "binary-search": "1.3.3",
             "pull-sink-through": "0.0.0",
-            "pull-stream": "^3.3.0",
-            "typewiselite": "^1.0.0"
+            "pull-stream": "3.6.8",
+            "typewiselite": "1.0.0"
           }
         },
         "minimist": {
@@ -5055,21 +4519,21 @@
           "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
           "dev": true,
           "requires": {
-            "detect-libc": "^1.0.3",
-            "expand-template": "^1.0.2",
+            "detect-libc": "1.0.3",
+            "expand-template": "1.1.1",
             "github-from-package": "0.0.0",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "node-abi": "^2.2.0",
-            "noop-logger": "^0.1.1",
-            "npmlog": "^4.0.1",
-            "os-homedir": "^1.0.1",
-            "pump": "^2.0.1",
-            "rc": "^1.1.6",
-            "simple-get": "^2.7.0",
-            "tar-fs": "^1.13.0",
-            "tunnel-agent": "^0.6.0",
-            "which-pm-runs": "^1.0.0"
+            "minimist": "1.2.0",
+            "mkdirp": "0.5.1",
+            "node-abi": "2.4.1",
+            "noop-logger": "0.1.1",
+            "npmlog": "4.1.2",
+            "os-homedir": "1.0.2",
+            "pump": "2.0.1",
+            "rc": "1.2.8",
+            "simple-get": "2.8.1",
+            "tar-fs": "1.16.2",
+            "tunnel-agent": "0.6.0",
+            "which-pm-runs": "1.0.0"
           }
         }
       }
@@ -5085,7 +4549,7 @@
       "integrity": "sha1-xoHaXNcMV0ySLcpPA8UhU4E1wkM=",
       "dev": true,
       "requires": {
-        "ssb-ref": "^2.0.0"
+        "ssb-ref": "2.11.1"
       }
     },
     "ssb-private": {
@@ -5093,14 +4557,14 @@
       "resolved": "https://registry.npmjs.org/ssb-private/-/ssb-private-0.1.4.tgz",
       "integrity": "sha1-pIywB7QeBtoGomy5ud4yoZj8I9M=",
       "requires": {
-        "base64-url": "^1.3.3",
-        "explain-error": "^1.0.4",
-        "flumeview-level": "^2.0.2",
-        "flumeview-query": "^3.0.3",
-        "map-filter-reduce": "^3.0.3",
+        "base64-url": "1.3.3",
+        "explain-error": "1.0.4",
+        "flumeview-level": "2.1.1",
+        "flumeview-query": "3.0.7",
+        "map-filter-reduce": "3.1.0",
         "pull-flatmap": "0.0.1",
-        "pull-stream": "^3.6.0",
-        "ssb-keys": "^7.0.9"
+        "pull-stream": "3.6.8",
+        "ssb-keys": "7.0.16"
       }
     },
     "ssb-query": {
@@ -5109,9 +4573,9 @@
       "integrity": "sha512-4QWvjSrSIon9qyhPHrqOeA/dp6NR7b11BtXKhJg/Di2r7/nBLGAj2RzUonfTfs3LlPHZdFWXowhhJREUAmUZug==",
       "dev": true,
       "requires": {
-        "explain-error": "^1.0.1",
-        "flumeview-query": "^6.0.0",
-        "pull-stream": "^3.6.2"
+        "explain-error": "1.0.4",
+        "flumeview-query": "6.2.0",
+        "pull-stream": "3.6.8"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -5120,7 +4584,7 @@
           "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
           "dev": true,
           "requires": {
-            "xtend": "~4.0.0"
+            "xtend": "4.0.1"
           }
         },
         "bindings": {
@@ -5135,7 +4599,7 @@
           "integrity": "sha512-ajbXqRPMXRlcdyt0TuWqknOJkp1JgQjGB7xOl2V+ebol7/U11E9h3/nCZAtN1M7djmAJEIhypCUc1tIWxdQAuQ==",
           "dev": true,
           "requires": {
-            "abstract-leveldown": "~4.0.0"
+            "abstract-leveldown": "4.0.3"
           }
         },
         "flumeview-level": {
@@ -5144,16 +4608,16 @@
           "integrity": "sha512-LKW+YdJGemOo7TnUwpFHq4cBBiYAIKtWk+G2CK7zrxbCIiAHemBRudohBOUKuSUZZ0CReR5fJ73peBHW02VerA==",
           "dev": true,
           "requires": {
-            "charwise": "^3.0.1",
-            "explain-error": "^1.0.4",
-            "level": "^3.0.1",
-            "ltgt": "^2.1.3",
-            "mkdirp": "^0.5.1",
+            "charwise": "3.0.1",
+            "explain-error": "1.0.4",
+            "level": "3.0.2",
+            "ltgt": "2.2.1",
+            "mkdirp": "0.5.1",
             "obv": "0.0.0",
-            "pull-level": "^2.0.3",
-            "pull-paramap": "^1.2.1",
-            "pull-stream": "^3.5.0",
-            "pull-write": "^1.1.1"
+            "pull-level": "2.0.4",
+            "pull-paramap": "1.2.2",
+            "pull-stream": "3.6.8",
+            "pull-write": "1.1.4"
           }
         },
         "flumeview-query": {
@@ -5162,13 +4626,13 @@
           "integrity": "sha512-tq7rD63gixBDOPegw10khz/d5Bnq9qW9IbURHbWuJkG5CUBm3JP4QQSIF/Phl99jz66MRuXoXjRrXXQLN89iNQ==",
           "dev": true,
           "requires": {
-            "deep-equal": "^1.0.1",
-            "flumeview-level": "^3.0.0",
-            "map-filter-reduce": "^3.0.7",
+            "deep-equal": "1.0.1",
+            "flumeview-level": "3.0.5",
+            "map-filter-reduce": "3.1.0",
             "pull-flatmap": "0.0.1",
-            "pull-paramap": "^1.1.3",
+            "pull-paramap": "1.2.2",
             "pull-sink-through": "0.0.0",
-            "pull-stream": "^3.4.0"
+            "pull-stream": "3.6.8"
           }
         },
         "level": {
@@ -5177,9 +4641,9 @@
           "integrity": "sha512-2qYbbiptPsPWGUI+AgB1gTNXqIjPpALRqrQyNx1zWYNZxhhuzEj/IE4Unu9weEBnsUEocfYe56xOGlAceb8/Fg==",
           "dev": true,
           "requires": {
-            "level-packager": "^2.0.2",
-            "leveldown": "^3.0.0",
-            "opencollective-postinstall": "^2.0.0"
+            "level-packager": "2.1.1",
+            "leveldown": "3.0.2",
+            "opencollective-postinstall": "2.0.0"
           }
         },
         "level-errors": {
@@ -5188,7 +4652,7 @@
           "integrity": "sha512-Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==",
           "dev": true,
           "requires": {
-            "errno": "~0.1.1"
+            "errno": "0.1.7"
           }
         },
         "level-iterator-stream": {
@@ -5197,9 +4661,9 @@
           "integrity": "sha512-GAHN00KMxAxyuBX7jdGAMnoOeVQOggRsJ0QJOtasnTVHgYHfvfwogXeROXHLWb/IJZWcR5a4BvSlrDNi2/RkUA==",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.5",
-            "xtend": "^4.0.0"
+            "inherits": "2.0.1",
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
           }
         },
         "level-packager": {
@@ -5208,8 +4672,8 @@
           "integrity": "sha512-6l3G6dVkmdvHwOJrEA9d9hL6SSFrzwjQoLP8HsvohOgfY/8Z9LyTKNCM5Gc84wtsUWCuIHu6r+S6WrCtTWUJCw==",
           "dev": true,
           "requires": {
-            "encoding-down": "~4.0.0",
-            "levelup": "^2.0.0"
+            "encoding-down": "4.0.1",
+            "levelup": "2.0.2"
           }
         },
         "leveldown": {
@@ -5218,11 +4682,11 @@
           "integrity": "sha512-+ANRScj1npQQzv6e4DYAKRjVQZZ+ahMoubKrNP68nIq+l9bYgb+WiXF+14oTcQTg2f7qE9WHGW7rBG9nGSsA+A==",
           "dev": true,
           "requires": {
-            "abstract-leveldown": "~4.0.0",
-            "bindings": "~1.3.0",
-            "fast-future": "~1.0.2",
-            "nan": "~2.10.0",
-            "prebuild-install": "^4.0.0"
+            "abstract-leveldown": "4.0.3",
+            "bindings": "1.3.0",
+            "fast-future": "1.0.2",
+            "nan": "2.10.0",
+            "prebuild-install": "4.0.0"
           }
         },
         "levelup": {
@@ -5231,10 +4695,10 @@
           "integrity": "sha512-us+nTLUyd/eLnclYYddOCdAVw1hnymGx/9p4Jr5ThohStsjLqMVmbYiz6/SYFZEPXNF+AKQSvh6fA2e2KZpC8w==",
           "dev": true,
           "requires": {
-            "deferred-leveldown": "~3.0.0",
-            "level-errors": "~1.1.0",
-            "level-iterator-stream": "~2.0.0",
-            "xtend": "~4.0.0"
+            "deferred-leveldown": "3.0.0",
+            "level-errors": "1.1.2",
+            "level-iterator-stream": "2.0.1",
+            "xtend": "4.0.1"
           }
         },
         "minimist": {
@@ -5255,21 +4719,21 @@
           "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
           "dev": true,
           "requires": {
-            "detect-libc": "^1.0.3",
-            "expand-template": "^1.0.2",
+            "detect-libc": "1.0.3",
+            "expand-template": "1.1.1",
             "github-from-package": "0.0.0",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "node-abi": "^2.2.0",
-            "noop-logger": "^0.1.1",
-            "npmlog": "^4.0.1",
-            "os-homedir": "^1.0.1",
-            "pump": "^2.0.1",
-            "rc": "^1.1.6",
-            "simple-get": "^2.7.0",
-            "tar-fs": "^1.13.0",
-            "tunnel-agent": "^0.6.0",
-            "which-pm-runs": "^1.0.0"
+            "minimist": "1.2.0",
+            "mkdirp": "0.5.1",
+            "node-abi": "2.4.1",
+            "noop-logger": "0.1.1",
+            "npmlog": "4.1.2",
+            "os-homedir": "1.0.2",
+            "pump": "2.0.1",
+            "rc": "1.2.8",
+            "simple-get": "2.8.1",
+            "tar-fs": "1.16.2",
+            "tunnel-agent": "0.6.0",
+            "which-pm-runs": "1.0.0"
           }
         }
       }
@@ -5279,8 +4743,17 @@
       "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.11.1.tgz",
       "integrity": "sha512-K3L9hJ1v0HrH8abtEKiBkdeabHVaws+CS81mZqUfhR84i0dlYhiIIDwqeLxUj/1mLcsZPF3gMKPsFCUr7UAdMA==",
       "requires": {
-        "ip": "^1.1.3",
-        "is-valid-domain": "~0.0.1"
+        "ip": "1.1.5",
+        "is-valid-domain": "0.0.5"
+      }
+    },
+    "ssb-schema-definitions": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/ssb-schema-definitions/-/ssb-schema-definitions-1.0.8.tgz",
+      "integrity": "sha512-VovK6XlES0v4DLSCQFHZHZnt5Y9o8X+F41vmrKNprMTlNJiUMD/daWUqai3fd17nDfvmxLb1bBjS3aOc9Mjjjg==",
+      "requires": {
+        "is-my-json-valid": "2.17.2",
+        "ssb-ref": "2.11.1"
       }
     },
     "ssb-sort": {
@@ -5288,7 +4761,7 @@
       "resolved": "https://registry.npmjs.org/ssb-sort/-/ssb-sort-1.1.0.tgz",
       "integrity": "sha512-UGn0GXkcpno7rNYWJhywmtKDnbhAHT3Nj++tMFP0pJ5shKL8SiipGYnjpZ8nVW185HNsEdsS06yJPD4o3hQyDQ==",
       "requires": {
-        "ssb-ref": "^2.3.0"
+        "ssb-ref": "2.11.1"
       }
     },
     "ssb-validate": {
@@ -5297,7 +4770,7 @@
       "integrity": "sha512-Gshbb8mgwtfJQTK66mCpORdMhDpe8l0GOv+3em1gWYHadWAV4Rx80RZ1NduD2NVzqupve12Qku5kQnrq0zJqjw==",
       "dev": true,
       "requires": {
-        "ssb-ref": "^2.6.2"
+        "ssb-ref": "2.11.1"
       }
     },
     "ssb-ws": {
@@ -5306,13 +4779,13 @@
       "integrity": "sha512-1fK/jXI6lKZadRJDr49t+6yMmWynp6PFrADs3Whmy8IslnYGl83ujhlpRIBvCn1EuVHjV7yLsIiJ8a0X2Kg0DQ==",
       "dev": true,
       "requires": {
-        "emoji-server": "^1.0.0",
-        "multiblob-http": "^0.4.1",
-        "multiserver": "^1.2.0",
-        "muxrpc": "^6.3.3",
-        "pull-box-stream": "^1.0.13",
-        "ssb-ref": "^2.3.0",
-        "stack": "^0.1.0"
+        "emoji-server": "1.0.0",
+        "multiblob-http": "0.4.2",
+        "multiserver": "1.12.0",
+        "muxrpc": "6.4.0",
+        "pull-box-stream": "1.0.13",
+        "ssb-ref": "2.11.1",
+        "stack": "0.1.0"
       }
     },
     "stack": {
@@ -5332,8 +4805,8 @@
       "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.2.tgz",
       "integrity": "sha1-dXYJrhzr0zx0MtSvvjH/eGULnd4=",
       "requires": {
-        "looper": "^3.0.0",
-        "pull-stream": "^3.2.3"
+        "looper": "3.0.0",
+        "pull-stream": "3.6.8"
       },
       "dependencies": {
         "looper": {
@@ -5343,14 +4816,22 @@
         }
       }
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "string.prototype.trim": {
@@ -5359,17 +4840,9 @@
       "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.0",
-        "function-bind": "^1.0.2"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "~5.1.0"
+        "define-properties": "1.1.2",
+        "es-abstract": "1.12.0",
+        "function-bind": "1.1.1"
       }
     },
     "stringify-entities": {
@@ -5378,10 +4851,10 @@
       "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
       "dev": true,
       "requires": {
-        "character-entities-html4": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
+        "character-entities-html4": "1.1.2",
+        "character-entities-legacy": "1.1.2",
+        "is-alphanumerical": "1.0.2",
+        "is-hexadecimal": "1.0.2"
       }
     },
     "strip-ansi": {
@@ -5389,7 +4862,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-json-comments": {
@@ -5408,13 +4881,13 @@
       "integrity": "sha1-j78zM9hWQ/7qG/F1m5CCCwSjfd8=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "diff": "^2.2.1",
-        "duplexer": "^0.1.1",
-        "figures": "^1.4.0",
-        "pretty-ms": "^2.1.0",
-        "tap-parser": "^1.2.2",
-        "through2": "^2.0.0"
+        "chalk": "1.1.3",
+        "diff": "2.2.3",
+        "duplexer": "0.1.1",
+        "figures": "1.7.0",
+        "pretty-ms": "2.1.0",
+        "tap-parser": "1.3.2",
+        "through2": "2.0.3"
       }
     },
     "tap-parser": {
@@ -5423,10 +4896,10 @@
       "integrity": "sha1-EgxQiciMPIp5PvKIhn3jIeGPjCI=",
       "dev": true,
       "requires": {
-        "events-to-array": "^1.0.1",
-        "inherits": "~2.0.1",
-        "js-yaml": "^3.2.7",
-        "readable-stream": "^2"
+        "events-to-array": "1.1.2",
+        "inherits": "2.0.1",
+        "js-yaml": "3.12.0",
+        "readable-stream": "2.3.6"
       }
     },
     "tape": {
@@ -5435,19 +4908,19 @@
       "integrity": "sha512-6fKIXknLpoe/Jp4rzHKFPpJUHDHDqn8jus99IfPnHIjyz78HYlefTGD3b5EkbQzuLfaEvmfPK3IolLgq2xT3kw==",
       "dev": true,
       "requires": {
-        "deep-equal": "~1.0.1",
-        "defined": "~1.0.0",
-        "for-each": "~0.3.3",
-        "function-bind": "~1.1.1",
-        "glob": "~7.1.2",
-        "has": "~1.0.3",
-        "inherits": "~2.0.3",
-        "minimist": "~1.2.0",
-        "object-inspect": "~1.6.0",
-        "resolve": "~1.7.1",
-        "resumer": "~0.0.0",
-        "string.prototype.trim": "~1.1.2",
-        "through": "~2.3.8"
+        "deep-equal": "1.0.1",
+        "defined": "1.0.0",
+        "for-each": "0.3.3",
+        "function-bind": "1.1.1",
+        "glob": "7.1.2",
+        "has": "1.0.3",
+        "inherits": "2.0.3",
+        "minimist": "1.2.0",
+        "object-inspect": "1.6.0",
+        "resolve": "1.7.1",
+        "resumer": "0.0.0",
+        "string.prototype.trim": "1.1.2",
+        "through": "2.3.8"
       },
       "dependencies": {
         "inherits": {
@@ -5486,10 +4959,10 @@
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.2.tgz",
       "integrity": "sha512-LdknWjPEiZC1nOBwhv0JBzfJBGPJar08dZg2rwZe0ZTLQoRGEzgrl7vF3qUEkCHpI/wN9e7RyCuDhMsJUCLPPQ==",
       "requires": {
-        "chownr": "^1.0.1",
-        "mkdirp": "^0.5.1",
-        "pump": "^1.0.0",
-        "tar-stream": "^1.1.2"
+        "chownr": "1.0.1",
+        "mkdirp": "0.5.1",
+        "pump": "1.0.3",
+        "tar-stream": "1.6.1"
       },
       "dependencies": {
         "pump": {
@@ -5497,8 +4970,8 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
           "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
           }
         }
       }
@@ -5508,13 +4981,13 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
       "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
       "requires": {
-        "bl": "^1.0.0",
-        "buffer-alloc": "^1.1.0",
-        "end-of-stream": "^1.0.0",
-        "fs-constants": "^1.0.0",
-        "readable-stream": "^2.3.0",
-        "to-buffer": "^1.1.0",
-        "xtend": "^4.0.0"
+        "bl": "1.2.2",
+        "buffer-alloc": "1.2.0",
+        "end-of-stream": "1.4.1",
+        "fs-constants": "1.0.0",
+        "readable-stream": "2.3.6",
+        "to-buffer": "1.1.1",
+        "xtend": "4.0.1"
       }
     },
     "text-table": {
@@ -5534,8 +5007,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "^2.1.5",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       }
     },
     "to-buffer": {
@@ -5554,7 +5027,7 @@
       "integrity": "sha1-iN7+zUOtsu9ZhiXw49WffzQpQbo=",
       "dev": true,
       "requires": {
-        "vfile": "^1.0.0"
+        "vfile": "1.4.0"
       }
     },
     "trim": {
@@ -5585,7 +5058,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
@@ -5598,7 +5071,7 @@
       "resolved": "https://registry.npmjs.org/tweetnacl-auth/-/tweetnacl-auth-0.3.1.tgz",
       "integrity": "sha1-t1vC3xVkm7hOi5qjwGacbEvODSU=",
       "requires": {
-        "tweetnacl": "0.x.x"
+        "tweetnacl": "0.14.5"
       }
     },
     "typedarray": {
@@ -5612,7 +5085,7 @@
       "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
       "integrity": "sha1-EGeTZUCvl5N8xdz5kiSG6fooRlE=",
       "requires": {
-        "typewise-core": "^1.2.0"
+        "typewise-core": "1.2.0"
       }
     },
     "typewise-core": {
@@ -5643,8 +5116,8 @@
       "integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "xtend": "^4.0.1"
+        "inherits": "2.0.1",
+        "xtend": "4.0.1"
       }
     },
     "unified": {
@@ -5653,12 +5126,12 @@
       "integrity": "sha1-FLxs1A2Y//91tAVQa62HPsu6w7o=",
       "dev": true,
       "requires": {
-        "attach-ware": "^1.0.0",
-        "bail": "^1.0.0",
-        "extend": "^3.0.0",
-        "unherit": "^1.0.4",
-        "vfile": "^1.0.0",
-        "ware": "^1.3.0"
+        "attach-ware": "1.1.1",
+        "bail": "1.0.3",
+        "extend": "3.0.1",
+        "unherit": "1.1.1",
+        "vfile": "1.4.0",
+        "ware": "1.3.0"
       }
     },
     "unist-util-is": {
@@ -5673,7 +5146,7 @@
       "integrity": "sha512-0fdB9EQJU0tho5tK0VzOJzAQpPv2LyLZ030b10GxuzAWEfvd54mpY7BMjQ1L69k2YNvL+SvxRzH0yUIehOO8aA==",
       "dev": true,
       "requires": {
-        "unist-util-is": "^2.1.1"
+        "unist-util-is": "2.1.2"
       }
     },
     "untildify": {
@@ -5682,7 +5155,7 @@
       "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0"
+        "os-homedir": "1.0.2"
       }
     },
     "user-home": {
@@ -5691,7 +5164,7 @@
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0"
+        "os-homedir": "1.0.2"
       }
     },
     "util-deprecate": {
@@ -5711,7 +5184,7 @@
       "integrity": "sha1-hKTWbQNRP2FAqE4Hdu8ISNTwrZU=",
       "dev": true,
       "requires": {
-        "to-vfile": "^1.0.0"
+        "to-vfile": "1.0.0"
       }
     },
     "vfile-find-up": {
@@ -5720,7 +5193,7 @@
       "integrity": "sha1-VgTab+RTs0NQY3mE61/kkJ4oA5A=",
       "dev": true,
       "requires": {
-        "to-vfile": "^1.0.0"
+        "to-vfile": "1.0.0"
       }
     },
     "vfile-reporter": {
@@ -5729,13 +5202,13 @@
       "integrity": "sha1-IacAm/5V4k34/0Mqpb9vbvp05Bg=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.0",
-        "log-symbols": "^1.0.2",
-        "plur": "^2.0.0",
-        "repeat-string": "^1.5.0",
-        "string-width": "^1.0.0",
-        "text-table": "^0.2.0",
-        "vfile-sort": "^1.0.0"
+        "chalk": "1.1.3",
+        "log-symbols": "1.0.2",
+        "plur": "2.1.2",
+        "repeat-string": "1.6.1",
+        "string-width": "1.0.2",
+        "text-table": "0.2.0",
+        "vfile-sort": "1.0.0"
       }
     },
     "vfile-sort": {
@@ -5750,7 +5223,7 @@
       "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
       "dev": true,
       "requires": {
-        "wrap-fn": "^0.1.0"
+        "wrap-fn": "0.1.5"
       }
     },
     "which": {
@@ -5759,7 +5232,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-pm-runs": {
@@ -5772,7 +5245,7 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "requires": {
-        "string-width": "^1.0.2 || 2"
+        "string-width": "1.0.2"
       }
     },
     "word-wrap": {
@@ -5801,8 +5274,8 @@
       "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
       "dev": true,
       "requires": {
-        "options": ">=0.0.5",
-        "ultron": "1.0.x"
+        "options": "0.0.6",
+        "ultron": "1.0.2"
       }
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "pull-next-query": "^1.0.0",
     "pull-stream": "^3.6.7",
     "scuttle-inject": "^1.0.0",
+    "ssb-backlinks": "^0.7.3",
     "ssb-invite-schema": "0.0.8",
     "ssb-msg-content": "^1.0.1",
     "ssb-private": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "pull-stream": "^3.6.7",
     "scuttle-inject": "^1.0.0",
     "ssb-backlinks": "^0.7.3",
-    "ssb-invite-schema": "0.0.8",
+    "ssb-invite-schema": "0.0.10",
     "ssb-msg-content": "^1.0.1",
     "ssb-private": "^0.1.4",
     "ssb-sort": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -16,9 +16,7 @@
     "pull-next-query": "^1.0.0",
     "pull-stream": "^3.6.7",
     "scuttle-inject": "^1.0.0",
-    "scuttle-invite-db": "0.0.7",
     "scuttle-invite-schema": "0.0.8",
-    "ssb-backlinks": "^0.6.1",
     "ssb-msg-content": "^1.0.1",
     "ssb-private": "^0.1.4",
     "ssb-sort": "^1.1.0"

--- a/test/async/canReply.test.js
+++ b/test/async/canReply.test.js
@@ -30,7 +30,7 @@ describe('invites.async.canReply', context => {
     publishEvent((err, event) => {
       params = Object.assign(params, {root: event.key})
       publishInvite(params, (err, invite) => {
-        CanReply(first)(invite, cannot => {
+        CanReply(first)(invite, (err, cannot) => {
           assert.notOk(cannot)
           next()
         })
@@ -46,7 +46,7 @@ describe('invites.async.canReply', context => {
     publishEvent((err, event) => {
       params = Object.assign(params, {root: event.key})
       publishInvite(params, (err, invite) => {
-        CanReply(second)(invite, can => {
+        CanReply(second)(invite, (err, can) => {
           assert.ok(can)
           next()
         })

--- a/test/async/getInvite.test.js
+++ b/test/async/getInvite.test.js
@@ -20,7 +20,7 @@ describe('invites.async.getInvite', context => {
     server.close()
   })
 
-  context("Returns a parsed Invite", (assert, next) => {
+  context("Returns an invite", (assert, next) => {
     publishEvent((err, event) => {
       var params = {
         root: event.key,
@@ -28,7 +28,8 @@ describe('invites.async.getInvite', context => {
         recps: [server.id, grace.id]
       }
       publishInvite(params, (err, invite) => {
-        getInvite(invite.id, (err, gotten) => {
+        getInvite(invite.key, (err, gotten) => {
+          delete invite.timestamp
           assert.deepEqual(invite, gotten, "publishInvite matches getInvite")
           assert.notOk(err, "Errors are null")
           next()

--- a/test/async/getReply.test.js
+++ b/test/async/getReply.test.js
@@ -1,19 +1,19 @@
 const { describe } = require('tape-plus')
 const { PublishEvent, Server } = require('../methods')
-const GetInvite = require('../../invites/async/getInvite')
-const PublishInvite = require('../../invites/async/publish')
+const GetReply = require('../../invites/async/getReply')
+const PublishReply = require('../../invites/async/publish')
 
 describe('invites.async.getReply', context => {
   let server, grace
-  let publishInvite, publishEvent, getInvite
+  let publishReply, publishEvent, getReply
 
   context.beforeEach(t => {
     server = Server()
     grace = server.createFeed()
 
     publishEvent = PublishEvent(server)
-    publishInvite = PublishInvite(server)
-    getInvite = GetInvite(server)
+    publishReply = PublishReply(server)
+    getReply = GetReply(server)
   })
 
   context.afterEach(t => {
@@ -27,9 +27,10 @@ describe('invites.async.getReply', context => {
         body: 'super secret cabal meeting',
         recps: [server.id, grace.id]
       }
-      publishInvite(params, (err, invite) => {
-        getInvite(invite.id, (err, gotten) => {
-          assert.deepEqual(invite, gotten, "publishInvite matches getInvite")
+      publishReply(params, (err, reply) => {
+        getReply(reply.key, (err, gotten) => {
+          delete reply.timestamp
+          assert.deepEqual(reply, gotten, "publishReply matches getReply")
           assert.notOk(err, "Errors are null")
           next()
         })

--- a/test/async/reply.test.js
+++ b/test/async/reply.test.js
@@ -3,6 +3,7 @@ const { PublishEvent, Server } = require('../methods')
 const PublishInvite = require('../../invites/async/publish')
 const PublishReply = require('../../invites/async/reply')
 const GetInvite = require('../../invites/async/getInvite')
+const { isReply } = require('scuttle-invite-schema')
 
 describe('invites.async.reply', context => {
   let server, grace
@@ -54,7 +55,7 @@ describe('invites.async.reply', context => {
       PublishInvite(third)(defaultParamsWithRoot, (err, invite) => {
         var replyParams = Object.assign({}, defaultParams, {
           root: event.key,
-          branch: invite.id,
+          branch: invite.key,
           recps: [...defaultParams.recps, server.id]
         })
         publishReply(replyParams, (err, reply) => {
@@ -72,24 +73,12 @@ describe('invites.async.reply', context => {
       publishInvite(defaultParamsWithRoot, (err, invite) => {
         var replyParams = Object.assign({}, defaultParams, {
           root: event.key,
-          branch: invite.id,
+          branch: invite.key,
         })
         publishReply(replyParams, (err, reply) => {
           assert.ok(reply, "Success")
           assert.notOk(err, "Errors are null")
-
-          const { id, timestamp } = reply
-          var reply = Object.assign({}, {
-            id,
-            author: server.id,
-            recipient: grace.id,
-            timestamp,
-            type: 'invite-reply',
-            version: 'v1'
-          }, replyParams)
-          delete reply.recps
-
-          assert.deepEqual(reply, reply, "Returns a parsed reply")
+          assert.ok(isReply(reply))
           next()
         })
       })

--- a/test/methods.js
+++ b/test/methods.js
@@ -7,7 +7,6 @@ function PublishEvent (server) {
 
 function Server () {
   return require('scuttle-testbot')
-    .use(require('scuttle-invite-db'))
     .use(require('ssb-private'))
     .use(require('ssb-query'))
     .call()

--- a/test/methods.js
+++ b/test/methods.js
@@ -7,6 +7,7 @@ function PublishEvent (server) {
 
 function Server () {
   return require('scuttle-testbot')
+    .use(require('ssb-backlinks'))
     .use(require('ssb-private'))
     .use(require('ssb-query'))
     .call()

--- a/test/pull/allByRoot.test.js
+++ b/test/pull/allByRoot.test.js
@@ -50,11 +50,11 @@ describe('invites.pull.byRoot', context => {
     publishEvent((err, event) => {
       pull(
         pull.values([
-          { type: 'invite', version: 'v1', recps: [grace.id, server.id], body: '1', root: event.key },
-          { type: 'invite', version: 'v1', recps: [grace.id, server.id], body: '2', root: event.key },
-          { type: 'invite', version: 'v1', recps: [grace.id, server.id], body: '3', root: event.key },
-          { type: 'invite', version: 'v1', recps: [grace.id, server.id], body: '4', root: event.key },
-          { type: 'invite', version: 'v1', recps: [grace.id, server.id], body: '5', root: event.key }
+          { type: 'invite', version: '1', recps: [grace.id, server.id], body: '1', root: event.key },
+          { type: 'invite', version: '1', recps: [grace.id, server.id], body: '2', root: event.key },
+          { type: 'invite', version: '1', recps: [grace.id, server.id], body: '3', root: event.key },
+          { type: 'invite', version: '1', recps: [grace.id, server.id], body: '4', root: event.key },
+          { type: 'invite', version: '1', recps: [grace.id, server.id], body: '5', root: event.key }
         ]),
         pull.asyncMap(server.publish),
         pull.collect((err, invites) => {
@@ -62,11 +62,11 @@ describe('invites.pull.byRoot', context => {
 
           pull(
             pull.values([
-              { type: 'invite-reply', version: 'v1', recps: [grace.id, server.id], body: '1', root: event.key, branch: first.key, accept: true },
-              { type: 'invite-reply', version: 'v1', recps: [grace.id, server.id], body: '2', root: event.key, branch: second.key, accept: true },
-              { type: 'invite-reply', version: 'v1', recps: [grace.id, server.id], body: '3', root: event.key, branch: third.key, accept: true },
-              { type: 'invite-reply', version: 'v1', recps: [grace.id, server.id], body: '4', root: event.key, branch: fourth.key, accept: true },
-              { type: 'invite-reply', version: 'v1', recps: [grace.id, server.id], body: '5', root: event.key, branch: fifth.key, accept: true }
+              { type: 'invite-reply', version: '1', recps: [grace.id, server.id], body: '1', root: event.key, branch: first.key, accept: true },
+              { type: 'invite-reply', version: '1', recps: [grace.id, server.id], body: '2', root: event.key, branch: second.key, accept: true },
+              { type: 'invite-reply', version: '1', recps: [grace.id, server.id], body: '3', root: event.key, branch: third.key, accept: true },
+              { type: 'invite-reply', version: '1', recps: [grace.id, server.id], body: '4', root: event.key, branch: fourth.key, accept: true },
+              { type: 'invite-reply', version: '1', recps: [grace.id, server.id], body: '5', root: event.key, branch: fifth.key, accept: true }
             ]),
             pull.asyncMap(grace.publish),
             pull.collect((err, replies) => {


### PR DESCRIPTION
@mixmix made these changes in anticipation of fixing [this issue with our tests in scuttle-dark-crystal](https://github.com/blockades/scuttle-dark-crystal/pull/5#discussion_r206028095) and [this one too](https://github.com/blockades/scuttle-dark-crystal/pull/5#discussion_r206186598). Lets save the 'decorating' or 'parsing' for the front-end.

I've also removed `ssb-invites-db` from the tests, removed `backlinks` since its not being used, and placed `query` in as an injectable dependency